### PR TITLE
Fix for "UnboundLocalError: local variable 'tmp_list' referenced before assignment"

### DIFF
--- a/modules/common.py
+++ b/modules/common.py
@@ -454,6 +454,7 @@ def tree(l):
 	"""
 	Given a list of files, find the complete list of hierarchy of extensions and return the result as a list
 	"""
+	tmp_list = []
 	for c in l:
 		if len(c)>0:
 			tmp_list+=find_ext(str(c[0]))


### PR DESCRIPTION
```
INFO - Content Providers appear to be in use, locating...
Traceback (most recent call last):
  File "qark.py", line 842, in <module>
    cp_dec_list=contentProvider.find_content_providers()
  File "qark/modules/contentProvider.py", line 22, in find_content_providers
    cp_list+=common.tree(cp_list)
  File "qark/modules/common.py", line 462, in tree
    return tmp_list
UnboundLocalError: local variable 'tmp_list' referenced before assignment
```