### PR TITLE
Dockerized QARK

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:2.7
+LABEL maintainer <ilya@ilyaglotov.com>
+
+# Install JRE
+RUN apt-get update && apt-get -y install openjdk-7-jre-headless \
+    curl
+
+RUN mkdir /qark
+WORKDIR /qark
+
+# Install Android SDK
+ENV ANDROID_SDK_VERSION r24.3.4
+ENV HOST_OS linux
+ENV ANDROID_SDK_PACKAGE="android-sdk_${ANDROID_SDK_VERSION}-${HOST_OS}.tgz"
+RUN curl -s https://dl.google.com/android/${ANDROID_SDK_PACKAGE} -o ${ANDROID_SDK_PACKAGE}
+RUN tar xzf ${ANDROID_SDK_PACKAGE}
+
+# Install QARK dependencies
+ADD . /qark
+WORKDIR /qark
+RUN pip install -r requirements.txt
+
+# Volume for an APK or application sources
+RUN mkdir /apk
+VOLUME /apk
+
+# By default QARK can start to analyze apks on the mounted volume. The subject to discuss.
+WORKDIR /qark/qark
+# CMD python qarkMain.py --source 1 --pathtoapk /apk/*.apk --exploit 0 --basepath /qark/android-sdk-linux -r /apk/

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN pip install -r requirements.txt
 RUN mkdir /apk
 VOLUME /apk
 
-# By default QARK can start to analyze apks on the mounted volume. The subject to discuss.
+# By default QARK can start to analyze apks on the mounted volume.
+# Report will be on the same folder.
 WORKDIR /qark/qark
-# CMD python qarkMain.py --source 1 --pathtoapk /apk/*.apk --exploit 0 --basepath /qark/android-sdk-linux -r /apk/
+# CMD python qarkMain.py --source 1 --pathtoapk /apk/*.apk --exploit 0 --basepath /qark/android-sdk-linux --reportdir /apk/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM python:2.7
-LABEL maintainer <ilya@ilyaglotov.com>
+LABEL url "https://www.github.com/linkedin/qark"
 
 # Install JRE
-RUN apt-get update && apt-get -y install openjdk-7-jre-headless \
-    curl
+RUN apt-get update && \
+    apt-get -y install openjdk-7-jre-headless \
+    curl \
+  && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /qark
 WORKDIR /qark
@@ -12,7 +14,9 @@ WORKDIR /qark
 ENV ANDROID_SDK_VERSION r24.3.4
 ENV HOST_OS linux
 ENV ANDROID_SDK_PACKAGE="android-sdk_${ANDROID_SDK_VERSION}-${HOST_OS}.tgz"
-RUN curl -s https://dl.google.com/android/${ANDROID_SDK_PACKAGE} -o ${ANDROID_SDK_PACKAGE}
+RUN curl -s https://dl.google.com/android/${ANDROID_SDK_PACKAGE} \
+    -o ${ANDROID_SDK_PACKAGE} \
+  && apt-get purge -y curl
 RUN tar xzf ${ANDROID_SDK_PACKAGE}
 
 # Install QARK dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,3 +33,5 @@ VOLUME /apk
 # By default QARK can start to analyze apks on the mounted volume.
 # Report will be on the same folder.
 # CMD python qarkMain.py --source 1 --pathtoapk /apk/*.apk --exploit 0 --basepath /qark/android-sdk-linux --reportdir /apk/
+
+ENTRYPOINT ["python", "qarkMain.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,17 @@ WORKDIR /qark
 ENV ANDROID_SDK_VERSION r24.3.4
 ENV HOST_OS linux
 ENV ANDROID_SDK_PACKAGE="android-sdk_${ANDROID_SDK_VERSION}-${HOST_OS}.tgz"
+
 RUN curl -s https://dl.google.com/android/${ANDROID_SDK_PACKAGE} \
     -o ${ANDROID_SDK_PACKAGE} \
-  && apt-get purge -y curl
-RUN tar xzf ${ANDROID_SDK_PACKAGE}
+  && apt-get purge -y curl \
+  && tar xzf ${ANDROID_SDK_PACKAGE} \
+  && rm -f ${ANDROID_SDK_PACKAGE}
 
 # Install QARK dependencies
-ADD . /qark
-WORKDIR /qark
-RUN pip install -r requirements.txt
+ADD qark requirements.txt /qark/
+RUN pip install -r requirements.txt \
+  && rm -rf /root/.cache
 
 # Volume for an APK or application sources
 RUN mkdir /apk
@@ -30,5 +32,4 @@ VOLUME /apk
 
 # By default QARK can start to analyze apks on the mounted volume.
 # Report will be on the same folder.
-WORKDIR /qark/qark
 # CMD python qarkMain.py --source 1 --pathtoapk /apk/*.apk --exploit 0 --basepath /qark/android-sdk-linux --reportdir /apk/


### PR DESCRIPTION
Hello,

## Why
I believe `docker pull` could be more convenient than installing everything by yourself. 

## Details
My Dockerfile uses `OpenJDK 7`, `python 2.7` and `Android SDK r24.3.4` - the very same version [as declared in sdkManager.py](https://github.com/linkedin/qark/blob/master/qark/modules/sdkManager.py#L76).

The `CMD` command is a subject to discuss, so I commented it out by now.

I set debian as the default base image because it just makes tinkering with the underlying container os easier, but I also made [lightweight alpine version](https://github.com/ilyaglow/qark/blob/dockerized-alpine/Dockerfile) if somebody interested.

## How to test dockerized version
You can pull my automated build this way (~~~1GB~~ *Update*: 675MB):
```
docker pull ilyaglow/qark
```
or the alpine version (~~~780MB~~ *Update*: 436 MB):
```
docker pull ilyaglow/qark:alpine
```
Then run it. Change `/assessment/apks` to your local path with an apk file or app sources:
```
docker run -it --rm -v /assessment/apks:/apk ilyaglow/qark --source 1 --pathtoapk /apk/yourvulnapp.apk --exploit 0 --reportdir /apk --basesdk /qark/android-sdk-linux
``` 
The report will be on the same folder

How to build it by yourself (assuming you're on the QARK repo):
```
git fetch origin pull/82/head:dockerized
git checkout dockerized
docker build -t my-qark -f Dockerfile .
```

Hope somebody will find it useful.

Cheers.