### PR TITLE
Change reportdir to reportDir to reduce confusion

### DIFF
--- a/qark/modules/report.py
+++ b/qark/modules/report.py
@@ -414,9 +414,8 @@ def reset():
     """
     try:
         common.reportDir = common.getConfig("rootDir") + "/report"
-        if common.args.reportdir is not None:
-            common.reportDir = common.args.reportdir + "/report"
-        # report_dir = common.args.reportdir
+        if common.args.reportDir is not None:
+            common.reportDir = common.args.reportDir + "/report"
         # common.writeKey("reportDir",report_dir);
 
         if os.path.exists(common.reportDir):

--- a/qark/qarkMain.py
+++ b/qark/qarkMain.py
@@ -392,7 +392,7 @@ def setup_argparse():
     optional.add_argument("-d", "--debug", dest="debuglevel",
                           help="Debug Level. 10=Debug, 20=INFO, 30=Warning, 40=Error")
     optional.add_argument("-v", "--version", dest="version", help="Print version info", action='store_true')
-    optional.add_argument("-r", "--reportdir", dest="reportdir",
+    optional.add_argument("-r", "--reportdir", dest="reportDir",
                           help="Specify full path for output report directory. Defaults to /report")
     required_group = required.add_mutually_exclusive_group()
     required_group.add_argument("-t", "--acceptterms", dest="acceptterms",


### PR DESCRIPTION
Addresses #128 

`common.args.reportDir` is specified by the user with the `--reportdir` flag and when `report.reset()` is called it will take the `common.args.reportDir` and put it into the `common.reportDir` where it is used by the application normally.