### PR TITLE
add filename to json/xml reports

### DIFF
--- a/qark/modules/common.py
+++ b/qark/modules/common.py
@@ -207,84 +207,6 @@ class terminalPrint():
         self.level = level
 
     def getLevel(self):
-        """
-        level = 0 represents Information Issue
-        self.extra retrieves information only from the Manifest.xml file. Hence it will be null for issues found from modules and plugins
-        self.data contains details/description for each issue
-        To get the type of Issue, looking at the specific issue keywords from the description is the only option at the moment
-        """
-        if self.level == 0:
-            tr = csv.writer(open('./Report.csv', 'a+'))
-
-            if self.extra:
-                tr.writerow(["INFO", str(self.data), str(self.extra), "Manifest File Check"])
-            elif "WEBVIEWS" in str(self.data):
-                tr.writerow(["INFO", str(self.data), str(self.extra), "WEB-VIEW ISSUES"])
-            elif "x.509" in str(self.data) or "certificate" in str(self.data) or "Man-In-The-Middle" in str(self.data):
-                tr.writerow(["INFO", str(self.data), str(self.extra), "CERTIFICATE VALIDATION ISSUES"])
-            elif "SecureRandom" in str(self.data) or "ECB" in str(self.data) or "key" in str(self.data):
-                tr.writerow(["INFO", str(self.data), str(self.extra), "CRYPTO ISSUES"])
-            elif "broadcast" in str(self.data):
-                tr.writerow(["INFO", str(self.data), str(self.extra), "BROADCAST ISSUES"])
-            elif "PendingIntent" in str(self.data):
-                tr.writerow(["INFO", str(self.data), str(self.extra), "PENDING INTENT ISSUES"])
-            else:
-                tr.writerow(["INFO", str(self.data), str(self.extra), "PLUGIN ISSUES"])
-
-        elif self.level == 1:
-            tr = csv.writer(open('./Report.csv', 'a+'))
-
-            if self.extra:
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "Manifest File Check"])
-            elif "WEBVIEWS" in str(self.data):
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "WEB-VIEW ISSUES"])
-            elif "x.509" in str(self.data) or "certificate" in str(self.data) or "Man-In-The-Middle" in str(self.data):
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "CERTIFICATE VALIDATION ISSUES"])
-            elif "SecureRandom" in str(self.data) or "ECB" in str(self.data) or "key" in str(self.data):
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "CRYPTO ISSUES"])
-            elif "broadcast" in str(self.data):
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "BROADCAST ISSUES"])
-            elif "PendingIntent" in str(self.data):
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "PENDING INTENT ISSUES"])
-            else:
-                tr.writerow(["WARNING", str(self.data), str(self.extra), "PLUGIN ISSUES"])
-
-        elif self.level == 2:
-            tr = csv.writer(open('./Report.csv', 'a+'))
-
-            if self.extra:
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "Manifest File Check"])
-            elif "WEBVIEWS" in str(self.data):
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "WEB-VIEW ISSUES"])
-            elif "x.509" in str(self.data) or "certificate" in str(self.data) or "Man-In-The-Middle" in str(self.data):
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "CERTIFICATE VALIDATION ISSUES"])
-            elif "SecureRandom" in str(self.data) or "ECB" in str(self.data) or "key" in str(self.data):
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "CRYPTO ISSUES"])
-            elif "broadcast" in str(self.data):
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "BROADCAST ISSUES"])
-            elif "PendingIntent" in str(self.data):
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "PENDING INTENT ISSUES"])
-            else:
-                tr.writerow(["ERROR", str(self.data), str(self.extra), "PLUGIN ISSUES"])
-
-        elif self.level == 3:
-            tr = csv.writer(open('./Report.csv', 'a+'))
-
-            if self.extra:
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "Manifest File Check"])
-            elif "WEBVIEWS" in str(self.data):
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "WEB-VIEW ISSUES"])
-            elif "x.509" in str(self.data) or "certificate" in str(self.data) or "Man-In-The-Middle" in str(self.data):
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "CERTIFICATE VALIDATION ISSUES"])
-            elif "SecureRandom" in str(self.data) or "ECB" in str(self.data) or "key" in str(self.data):
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "CRYPTO ISSUES"])
-            elif "broadcast" in str(self.data):
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "BROADCAST ISSUES"])
-            elif "PendingIntent" in str(self.data):
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "PENDING INTENT ISSUES"])
-            else:
-                tr.writerow(["VULNERABILITY", str(self.data), str(self.extra), "PLUGIN ISSUES"])
-
         return self.level
 
     def setData(self, data):
@@ -1213,7 +1135,7 @@ class ReportIssue():
     name = ""
     extra = {}
 
-    def __init__(self, category="", severity="", details="", file="", name="", extra=None):
+    def __init__(self, category="", severity=0, details="", file="", name="", extra=None):
         self.category = category
         self.severity = severity
         self.details = details
@@ -1259,3 +1181,14 @@ class ReportIssue():
 
     def setExtras(self, key, value):
         self.extra[key] = value
+
+    def get_severity_string(self):
+        if self.severity == Severity.INFO:
+            return "INFO"
+        elif self.severity == Severity.WARNING:
+            return "WARNING"
+        elif self.severity == Severity.ERROR:
+            return "ERROR"
+        elif self.severity == Severity.VULNERABILITY:
+            return "VULNERABILITY"
+        return ""

--- a/qark/modules/report.py
+++ b/qark/modules/report.py
@@ -424,3 +424,28 @@ def reset():
         os.rename(common.reportDir + "/index.html", common.reportDir + "/report.html")
     except Exception as e:
         common.logger.debug("Error when trying to reset report")
+
+
+def write_csv_section(issue, csv_file):
+    """
+    level = 0 represents Information Issue
+    self.extra retrieves information only from the Manifest.xml file. Hence it will be null for issues found from modules and plugins
+    self.data contains details/description for each issue
+    To get the type of Issue, looking at the specific issue keywords from the description is the only option at the moment
+    """
+    severity = issue.get_severity_string()
+
+    if issue.extra:
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "Manifest File Check"])
+    elif "WEBVIEWS" in str(issue.details):
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "WEB-VIEW ISSUES"])
+    elif "x.509" in str(issue.details) or "certificate" in str(issue.details) or "Man-In-The-Middle" in str(issue.details):
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "CERTIFICATE VALIDATION ISSUES"])
+    elif "SecureRandom" in str(issue.details) or "ECB" in str(issue.details) or "key" in str(issue.details):
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "CRYPTO ISSUES"])
+    elif "broadcast" in str(issue.details):
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "BROADCAST ISSUES"])
+    elif "PendingIntent" in str(issue.details):
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "PENDING INTENT ISSUES"])
+    else:
+        csv_file.writerow([severity, str(issue.details), str(issue.file), str(issue.extra), "PLUGIN ISSUES"])

--- a/qark/qarkMain.py
+++ b/qark/qarkMain.py
@@ -353,6 +353,9 @@ def writeReportSection(results, category):
         common.logger.log(common.HEADER_ISSUES_LEVEL, category)
     if not any(isinstance(x, terminalPrint) for x in results):
         common.logger.info(" No issues to report")
+
+    csv_file = open('./Report.csv', 'a+')
+    writer = csv.writer(csv_file)
     for item in results:
         if isinstance(item, terminalPrint):
             if item.getLevel() == Severity.INFO:
@@ -363,6 +366,9 @@ def writeReportSection(results, category):
                 common.logger.error(item.getData())
             if item.getLevel() == Severity.VULNERABILITY:
                 common.logger.log(common.VULNERABILITY_LEVEL,item.getData())
+        elif isinstance(item, ReportIssue):
+            report.write_csv_section(item, writer)
+    csv_file.close()
 
 def setup_argparse():
     parser = argparse.ArgumentParser(description='QARK - Andr{o}id Source Code Analyzer and Exploitation Tool')
@@ -1212,7 +1218,7 @@ def main():
             data = [line for line in r]
         with open('./Report.csv', 'w') as f:
             w = csv.writer(f)
-            w.writerow(["severity", "details", "extra", "type"])
+            w.writerow(["severity", "details", "file", "extra", "type"])
             w.writerows(data)
 
         # Convert CSV to JSON

--- a/qark/test/test_common.py
+++ b/qark/test/test_common.py
@@ -106,3 +106,16 @@ def test_get_entry_for_component():
     assert ['onReceive'] == qark.modules.common.get_entry_for_component("receiver")
     assert ['onCreate', 'onBind', 'onStartCommand', 'onHandleIntent'] == qark.modules.common.get_entry_for_component("service")
     assert ['onReceive'] == qark.modules.common.get_entry_for_component("provider")
+
+
+def test_report_issue():
+    issue = common.ReportIssue(category="test_category", severity=0, details="test_details",
+                               file="test_filename", name="test_name")
+    assert "INFO" == issue.get_severity_string()
+    issue.severity = 1
+    assert "WARNING" == issue.get_severity_string()
+    issue.severity = 2
+    assert "ERROR" == issue.get_severity_string()
+    issue.severity = 3
+    assert "VULNERABILITY" == issue.get_severity_string()
+    issue.severity = 4

--- a/qark/test/test_modules/test_report.py
+++ b/qark/test/test_modules/test_report.py
@@ -1,0 +1,45 @@
+import csv
+import os
+
+import qark.modules.report
+import qark.modules.common
+
+
+def test_write_csv_section():
+    issue = qark.modules.common.ReportIssue(severity=0, details="test_details", file="test_filename")
+    csv_file = open("test_csv_file.csv", "w")
+    writer = csv.writer(csv_file)
+    qark.modules.report.write_csv_section(issue, writer)
+    csv_file.close()
+    file_contents_okay("INFO")
+
+    issue = qark.modules.common.ReportIssue(severity=1, details="test_details", file="test_filename")
+    csv_file = open("test_csv_file.csv", "w")
+    writer = csv.writer(csv_file)
+    qark.modules.report.write_csv_section(issue, writer)
+    csv_file.close()
+    file_contents_okay("WARNING")
+
+    issue = qark.modules.common.ReportIssue(severity=2, details="test_details", file="test_filename")
+    csv_file = open("test_csv_file.csv", "w")
+    writer = csv.writer(csv_file)
+    qark.modules.report.write_csv_section(issue, writer)
+    csv_file.close()
+    file_contents_okay("ERROR")
+
+    issue = qark.modules.common.ReportIssue(severity=3, details="test_details", file="test_filename")
+    csv_file = open("test_csv_file.csv", "w")
+    writer = csv.writer(csv_file)
+    qark.modules.report.write_csv_section(issue, writer)
+    csv_file.close()
+    file_contents_okay("VULNERABILITY")
+
+    os.remove("test_csv_file.csv")
+
+
+def file_contents_okay(severity):
+    with open("test_csv_file.csv", "r") as f:
+        contents = "\n".join(f.readlines())
+        assert severity in contents
+        assert "test_details" in contents
+        assert "test_filename" in contents


### PR DESCRIPTION
Puts `file` as a new field in the JSON and XML reports. Also cleans up how JSON/XML were previously done.
Moves code from `common.py` into `report.py` and condenses it. 
New functionality tested via `test_common.py` and `test_report.py`