### PR TITLE
Add basic CLI that supports APK, Java files, and a single Java file

### DIFF
--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -49,7 +49,7 @@ class Decompiler(object):
 
         # validate we are running on an APK, Directory, or Java source code
         if not os.path.exists(self.path_to_source):
-            return
+            raise ValueError("Invalid path, path must be to an APK, directory, or a Java file")
 
         if os.path.isfile(self.path_to_source) and os.path.splitext(self.path_to_source.lower())[1] not in (".java", ".apk"):
             return

--- a/qark/plugins/cert/cert_validation_methods_overriden.py
+++ b/qark/plugins/cert/cert_validation_methods_overriden.py
@@ -47,7 +47,7 @@ class CertValidation(BasePlugin):
 
         try:
             tree = javalang.parse.parse(file_contents)
-        except javalang.parser.JavaSyntaxError:
+        except (javalang.parser.JavaSyntaxError, IndexError):
             log.debug("Couldn't parse the java file: %s", filepath)
             return
         current_file = filepath

--- a/qark/plugins/cert/hostname_verifier.py
+++ b/qark/plugins/cert/hostname_verifier.py
@@ -45,7 +45,7 @@ class HostnameVerifier(BasePlugin):
 
         try:
             tree = javalang.parse.parse(file_contents)
-        except javalang.parser.JavaSyntaxError:
+        except (javalang.parser.JavaSyntaxError, IndexError):
             log.debug("Couldn't parse the java file: %s", filepath)
             return
 

--- a/qark/plugins/crypto/ecb_cipher_usage.py
+++ b/qark/plugins/crypto/ecb_cipher_usage.py
@@ -6,6 +6,7 @@ import javalang
 
 from qark.scanner.plugin import BasePlugin
 from qark.issue import Severity, Issue
+from qark.plugins.helpers import java_files_from_files
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ class ECBCipherCheck(BasePlugin):
 
         try:
             tree = javalang.parse.parse(body)
-        except Exception:
+        except (javalang.parser.JavaSyntaxError, IndexError):
             log.debug("Couldn't parse the java file: %s", filepath)
             return
 
@@ -47,6 +48,9 @@ class ECBCipherCheck(BasePlugin):
                 continue
 
     def run(self, files, apk_constants=None):
-        relevant_files = (file_path for file_path in files if os.path.splitext(file_path)[1] == '.java')
+        relevant_files = java_files_from_files(files)
         for file_path in relevant_files:
             self._process_file(file_path)
+
+
+plugin = ECBCipherCheck()

--- a/qark/plugins/crypto/packaged_private_keys.py
+++ b/qark/plugins/crypto/packaged_private_keys.py
@@ -24,3 +24,6 @@ class PackagedPrivateKeys(BasePlugin):
                     description = "It appears there is a private key embedded in your application in the following file:"
                     self.issues.append(
                         Issue(self.category, self.name, self.severity, description, file_object=file_path))
+
+
+plugin = PackagedPrivateKeys()

--- a/qark/plugins/helpers.py
+++ b/qark/plugins/helpers.py
@@ -51,7 +51,7 @@ def get_target_sdk(manifest_xml, files=None):
     :param Set[str] files: list of files received from Scanner
     :return: int of the version if it exists, else 1 (the default)
     """
-    if files:
+    if manifest_xml is None and files:
         manifest_xml = get_manifest_out_of_files(files)
 
     if isinstance(manifest_xml, str):

--- a/qark/plugins/helpers.py
+++ b/qark/plugins/helpers.py
@@ -23,7 +23,7 @@ def get_min_sdk(manifest_xml, files=None):
     :param Set[str] files: list of files received from Scanner
     :return: int of the version if it exists, else 1 (the default)
     """
-    if files:
+    if manifest_xml is None and files:
         manifest_xml = get_manifest_out_of_files(files)
 
     if isinstance(manifest_xml, str):
@@ -101,7 +101,7 @@ def run_regex(filename, rex):
     except IOError:
         log.debug("Unable to open file: %s results will be inaccurate", filename)
     except UnicodeDecodeError:
-        pass
+        log.debug("Error reading file: %s most likely it is of an invalid type", filename)
     except Exception:
         log.exception("Failed to read file: %s", filename)
     return things_to_inspect

--- a/qark/plugins/intent/implicit_intent_to_pending_intent.py
+++ b/qark/plugins/intent/implicit_intent_to_pending_intent.py
@@ -56,7 +56,7 @@ class ImplicitIntentToPendingIntent(BasePlugin):
 
             try:
                 parsed_tree = javalang.parse.parse(file_contents)
-            except javalang.parser.JavaSyntaxError:
+            except (javalang.parser.JavaSyntaxError, IndexError):
                 log.debug("Error parsing file %s, continuing", java_file)
                 continue
 

--- a/qark/plugins/manifest/allow_backup.py
+++ b/qark/plugins/manifest/allow_backup.py
@@ -19,6 +19,9 @@ class ManifestBackupAllowed(BasePlugin):
 
     def run(self, files, apk_constants=None):
         manifest_path = get_manifest_out_of_files(files)
+        if not manifest_path:
+            return
+
         try:
             manifest_xml = minidom.parse(manifest_path)
         except Exception:

--- a/qark/plugins/manifest/custom_permissions.py
+++ b/qark/plugins/manifest/custom_permissions.py
@@ -18,9 +18,12 @@ class CustomPermissions(BasePlugin):
         self.severity = Severity.WARNING
 
     def run(self, files, apk_constants=None):
-        mainfest_path = get_manifest_out_of_files(files)
+        manifest_path = get_manifest_out_of_files(files)
+        if not manifest_path:
+            return
+
         try:
-            manifest_xml = minidom.parse(mainfest_path)
+            manifest_xml = minidom.parse(manifest_path)
         except Exception:
             log.exception("Failed to parse manifest file, is it valid syntax?")
             return  # do not raise a SystemExit because other checks can still be ran
@@ -29,10 +32,10 @@ class CustomPermissions(BasePlugin):
         for permission in permission_sections:
             try:
                 if permission.attributes["android:protectionLevel"].value in ("signature", "signatureOrSystem"):
-                    if apk_constants.get("minimum_sdk", get_min_sdk(manifest_xml)) < 21:
+                    if apk_constants.get("min_sdk", get_min_sdk(manifest_xml)) < 21:
                         self.issues.append(Issue(category=self.category, severity=self.severity,
                                                  name=self.name, description=self.description,
-                                                 file_object=mainfest_path))
+                                                 file_object=manifest_path))
 
             except KeyError:
                 continue

--- a/qark/plugins/manifest/debuggable.py
+++ b/qark/plugins/manifest/debuggable.py
@@ -22,6 +22,9 @@ class DebuggableManifest(BasePlugin):
 
     def run(self, files, apk_constants=None):
         manifest_path = get_manifest_out_of_files(files)
+        if not manifest_path:
+            return
+
         try:
             manifest_xml = minidom.parse(manifest_path)
         except Exception:

--- a/qark/plugins/manifest/exported_tags.py
+++ b/qark/plugins/manifest/exported_tags.py
@@ -129,13 +129,16 @@ class ExportedTags(BasePlugin):
 
     def run(self, files, apk_constants=None):
         manifest_file = get_manifest_out_of_files(files)
+        if not manifest_file:
+            return
+
         try:
             self.manifest_xml = minidom.parse(manifest_file)
         except Exception:
             log.exception("Failed to parse manifest file, is it valid syntax?")
             return  # do not raise a SystemExit because other checks can still be ran
 
-        self.min_sdk = apk_constants.get("minimum_sdk", get_min_sdk(self.manifest_xml))
+        self.min_sdk = apk_constants.get("min_sdk", get_min_sdk(self.manifest_xml))
         self.target_sdk = apk_constants.get("target_sdk", get_target_sdk(self.manifest_xml))
 
         for tag in self.bad_exported_tags:

--- a/qark/plugins/manifest/min_sdk.py
+++ b/qark/plugins/manifest/min_sdk.py
@@ -30,6 +30,9 @@ class MinSDK(BasePlugin):
             min_sdk = apk_constants["min_sdk"]
         except (KeyError, TypeError):
             manifest_path = get_manifest_out_of_files(files)
+            if not manifest_path:
+                return
+
             try:
                 manifest_xml = minidom.parse(manifest_path)
             except Exception:

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -1,6 +1,53 @@
-def main():
+import logging
+
+import click
+
+from qark.decompiler.decompiler import Decompiler
+from qark.scanner.scanner import Scanner
+from qark.report import Report
+
+log = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option("--sdk-path", type=click.Path(exists=True, file_okay=False, resolve_path=True),
+              help="Path to the downloaded SDK directory if already downloaded")
+@click.option("--build-path", type=click.Path(resolve_path=True, file_okay=False),
+              help="Path to place decompiled files and exploit APK", default="build", show_default=True)
+@click.option("--debug/--no-debug", default=False, help="Show debugging statements (helpful for issues)",
+              show_default=True)
+@click.option("--apk", "source", help="APK to decompile and run static analysis. If passed, "
+                                      "the --java option is not used",
+              type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=True))
+@click.option("--java", "source", type=click.Path(exists=True, resolve_path=True, file_okay=True, dir_okay=True),
+              help="A directory containing Java code, or a Java file, to decompile and run static analysis. If passed,"
+                   "the --apk option is not used")
+@click.option("--report-type", type=click.Choice(["html", "xml", "json", "csv"]),
+              help="Type of report to generate along with terminal output", default="html", show_default=True)
+@click.option("--exploit-apk/--no-exploit-apk", default=False,
+              help="Create an exploit APK targetting a few vulnerabilities", show_default=True)
+@click.version_option()
+def cli(sdk_path, build_path, debug, source, report_type, exploit_apk):
+    click.secho("Decompiling...")
+    decompiler = Decompiler(path_to_apk=source, build_directory=build_path)
+    decompiler.decompile()
+
+    click.secho("Running scans...")
+    scanner = Scanner(decompiler=decompiler)
+    scanner.run()
+    click.secho("Finish scans...")
+
+    click.secho("Writing report...")
+    report = Report(issues=scanner.issues)
+    report.generate_report_file(file_type=report_type)
+    click.secho("Finish writing report...")
+
+
+# @cli.command()
+@click.option("--apk", required=True, type=click.Path(exists=True, resolve_path=True, file_okay=True,
+                                                           dir_okay=False),
+              help="Path to APK to decompile")
+@click.option("--build-path", type=click.Path(resolve_path=True, file_okay=False),
+              help="Path to place decompiled files and exploit APK", default="build", show_default=True)
+def decompile(apk, build_path):
     pass
-
-
-if __name__ == "__main__":
-    main()

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -31,7 +31,7 @@ log = logging.getLogger(__name__)
 @click.version_option()
 def cli(sdk_path, build_path, debug, source, report_type, exploit_apk):
     click.secho("Decompiling...")
-    decompiler = Decompiler(path_to_apk=source, build_directory=build_path)
+    decompiler = Decompiler(path_to_source=source, build_directory=build_path)
     decompiler.decompile()
 
     click.secho("Running scans...")

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import
+
 import logging
 
 import click

--- a/qark/report.py
+++ b/qark/report.py
@@ -28,13 +28,13 @@ class Report(object):
     # http://python-3-patterns-idioms-test.readthedocs.io/en/latest/Singleton.html#the-singleton
     __instance = None
 
-    def __new__(cls, report_path=None):
+    def __new__(cls, issues=None, report_path=None):
         if Report.__instance is None:
             Report.__instance = object.__new__(cls)
-        Report.__instance.report_path = report_path
+
         return Report.__instance
 
-    def __init__(self, report_path=None):
+    def __init__(self, issues=None, report_path=None):
         """This will give you an instance of a report, with a default report path which is local
         to where QARK is on the file system.
 
@@ -42,7 +42,7 @@ class Report(object):
         :type report_path: str or None
 
         """
-        self.issues = []
+        self.issues = issues if issues is not None else []
         self.report_path = report_path or DEFAULT_REPORT_PATH
 
     def generate_report_file(self, file_type='html', template_file=None):

--- a/qark/report.py
+++ b/qark/report.py
@@ -42,7 +42,7 @@ class Report(object):
         :type report_path: str or None
 
         """
-        self.issues = issues if issues is not None else []
+        self.issues = issues if issues else []
         self.report_path = report_path or DEFAULT_REPORT_PATH
 
     def generate_report_file(self, file_type='html', template_file=None):

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -53,6 +53,6 @@ class BasePlugin(object):
 
         :param List[str] files: a list of files gathered by `Scanner` as absolute paths
         :param dict apk_constants: dictionary containing extra information
-                                    that some plugins can use (minimum_sdk, target_sdk)
+                                    that some plugins can use (min_sdk, target_sdk)
         """
         pass

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -50,7 +50,7 @@ class Scanner(object):
             target_sdk = get_target_sdk(self.decompiler.manifest_path, files=self.files)
         except AttributeError:
             # manifest path is not set, assume min_sdk and target_sdk
-            min_sdk = target_sdk = 15
+            min_sdk = target_sdk = 1
 
         for plugin_name in get_plugins(category=category):
             try:

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -78,8 +78,8 @@ class Scanner(object):
         Walks the `Decompiler.build_directory` and updates the `self.files` set with new files.
         :return:
         """
-        if path.splitext(self.decompiler.path_to_apk.lower())[1] == ".java":
-            self.files.add(self.decompiler.path_to_apk)
+        if path.splitext(self.decompiler.path_to_source.lower())[1] == ".java":
+            self.files.add(self.decompiler.path_to_source)
             return
 
         walk_directory = self.decompiler.build_directory

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -31,11 +31,6 @@ class Scanner(object):
         :param Decompiler decompiler: the decompiler class that contains decompiled path information
         """
         self.decompiler = decompiler
-        if decompiler.source_code:
-            return
-
-        if self.decompiler.manifest_path is None:
-            self.decompiler.manifest_path = self.decompiler.run_apktool()
 
     def run(self):
         """

--- a/qark/templates/html_report.jinja
+++ b/qark/templates/html_report.jinja
@@ -3,7 +3,9 @@
 <body>
 <h1>Issues</h1>
 {% for issue in issues %}
-{{ issue.severity.name }} {{ issue.name }}
+<h2>{{ issue.severity.name }} {{ issue.name }}</h2>
+{{ issue.description }} <br/><br/>
+File: <a href="file://{{ issue.file_object }}">{{ issue.file_object }}{% if issue.line_number %}:{{ issue.line_number[0] }}:{{ issue.line_number[1] }} {% endif %}</a><br/>
 {% endfor %}
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pluginbase
 jinja2
 enum34; python_version < '3.4'
 javalang
+click

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup, find_packages
+
+with open('requirements.txt') as f:
+    required = f.read().splitlines()
+
+setup(
+    name="qark",
+    version="2.0",
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=required,
+    # metadata for upload to PyPI
+    # author="Tushar Dalvi & Tony Trummer",
+    # author_email="tushardalvi@gmail.com, tonytrummer@hotmail.com",
+    description="Android static code analyzer",
+    license="Apache 2.0",
+    keywords="android security qark exploit",
+    url="https://www.github.com/linkedin/qark",
+    entry_points="""
+        [console_scripts]
+        qark=qark.qark:cli""",
+)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from qark.scanner.scanner import Scanner
 
 
 @pytest.fixture(scope="session")
-def path_to_apk():
+def path_to_source():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "goatdroid.apk")
 
 
@@ -17,8 +17,8 @@ def build_directory():
 
 
 @pytest.fixture()
-def decompiler(path_to_apk, build_directory):
-    return Decompiler(path_to_apk=path_to_apk, build_directory=build_directory)
+def decompiler(path_to_source, build_directory):
+    return Decompiler(path_to_source=path_to_source, build_directory=build_directory)
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,11 +27,6 @@ def scanner(decompiler):
 
 
 @pytest.fixture(scope="session")
-def bad_decompiler():
-    return Decompiler("1")
-
-
-@pytest.fixture(scope="session")
 def cfr_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib", "decompilers", "cfr_0_124.jar")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def path_to_apk():
 
 @pytest.fixture(scope="session")
 def build_directory():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "unzip_apk")
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "build_directory")
 
 
 @pytest.fixture()

--- a/tests/test_decompiler/test_decompiler.py
+++ b/tests/test_decompiler/test_decompiler.py
@@ -51,8 +51,8 @@ def test_download_procyon(procyon_path):
     assert not os.path.isfile(procyon_path)
 
 
-def test_unzip_file(path_to_apk, build_directory):
-    decompiler.unzip_file(path_to_apk, destination_to_unzip=build_directory)
+def test_unzip_file(path_to_source, build_directory):
+    decompiler.unzip_file(path_to_source, destination_to_unzip=build_directory)
 
     with pytest.raises(SystemExit):
         decompiler.unzip_file("1")

--- a/tests/test_decompiler/test_decompiler.py
+++ b/tests/test_decompiler/test_decompiler.py
@@ -67,63 +67,54 @@ def test_get_java_version():
     assert not java_version.endswith('"')
 
 
-def test_unpack_apk(decompiler, bad_decompiler, build_directory):
-    classes_dex_path = os.path.join(build_directory, "classes.dex")
-    assert classes_dex_path == decompiler._unpack_apk()
+def test_ran_unpack_apk(decompiler, bad_decompiler):
+    classes_dex_path = os.path.join(decompiler.build_directory, "classes.dex")
+    assert classes_dex_path == decompiler.dex_path
     assert os.path.isfile(classes_dex_path)
 
-    shutil.rmtree(build_directory)
-    assert not os.path.isdir(build_directory)
+    shutil.rmtree(decompiler.build_directory)
+    assert not os.path.isdir(decompiler.build_directory)
 
     with pytest.raises(SystemExit):
         bad_decompiler._unpack_apk()
 
 
-def test_run_apktool(decompiler, build_directory):
-    assert not os.path.isdir(build_directory)
-
-    decompiler.run_apktool()
-    assert os.path.isdir(build_directory)
+def test_ran_apktool(decompiler):
     assert os.path.isfile(os.path.join(decompiler.build_directory, "AndroidManifest.xml"))
 
-    shutil.rmtree(build_directory)
-    assert not os.path.isdir(build_directory)
+    shutil.rmtree(decompiler.build_directory)
+    assert not os.path.isdir(decompiler.build_directory)
 
 
-def test_run_dex2jar(decompiler, build_directory):
-    assert not os.path.isdir(build_directory)
+def test_ran_dex2jar(decompiler):
+    assert os.path.isfile(decompiler.jar_path)
+    assert decompiler.jar_path.endswith(".jar")
 
-    decompiler.dex_path = decompiler._unpack_apk()
-    jar_file = decompiler._run_dex2jar()
-    assert os.path.isfile(jar_file)
-    assert jar_file.endswith(".jar")
-
-    shutil.rmtree(build_directory)
-    assert not os.path.isdir(build_directory)
+    shutil.rmtree(decompiler.build_directory)
+    assert not os.path.isdir(decompiler.build_directory)
 
 
-def test_decompile(decompiler, build_directory):
-    assert not os.path.isdir(build_directory)
+def test_decompile(decompiler):
+    jdcore_decomp_path = os.path.join(decompiler.build_directory, "jdcore")
+    procyon_decomp_path = os.path.join(decompiler.build_directory, "procyon")
+    cfr_decomp_path = os.path.join(decompiler.build_directory, "cfr")
+    assert all([not os.path.exists(path) for path in (jdcore_decomp_path, procyon_decomp_path, cfr_decomp_path)])
 
-    decompiler._run_dex2jar()
     decompiler.decompile()
 
-    assert os.path.isdir(build_directory)
+    assert os.path.isdir(decompiler.build_directory)
 
-    jdcore_decomp_path = os.path.join(build_directory, "jdcore")
     assert os.path.isdir(jdcore_decomp_path)
     assert os.path.isdir(os.path.join(jdcore_decomp_path, "org"))
 
-    procyon_decomp_path = os.path.join(build_directory, "procyon")
     assert os.path.isdir(procyon_decomp_path)
     assert os.path.isdir(os.path.join(procyon_decomp_path, "org"))
 
-    cfr_decomp_path = os.path.join(build_directory, "cfr")
     assert os.path.isdir(cfr_decomp_path)
     assert os.path.isdir(os.path.join(cfr_decomp_path, "org"))
 
-    shutil.rmtree(build_directory)
-    assert not os.path.isdir(build_directory)
+    shutil.rmtree(decompiler.build_directory)
+    assert not os.path.isdir(decompiler.build_directory)
 
 
 @pytest.mark.parametrize("external_decompiler", [
@@ -131,14 +122,10 @@ def test_decompile(decompiler, build_directory):
     (CFR()),
     (Procyon()),
 ])
-def test_decompiler_function(decompiler, build_directory, external_decompiler):
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
-    assert not os.path.isdir(build_directory)
-
+def test_decompiler_function(decompiler, external_decompiler):
     decompiler._decompiler_function(external_decompiler)
-    decompiler_build_directory = os.path.join(build_directory, external_decompiler.name)
+    decompiler_build_directory = os.path.join(decompiler.build_directory, external_decompiler.name)
     assert os.path.isdir(decompiler_build_directory)
     assert os.path.isdir(os.path.join(decompiler_build_directory, "org"))
-    shutil.rmtree(build_directory)
-    assert not os.path.isdir(build_directory)
+    shutil.rmtree(decompiler.build_directory)
+    assert not os.path.isdir(decompiler.build_directory)

--- a/tests/test_decompiler/test_decompiler.py
+++ b/tests/test_decompiler/test_decompiler.py
@@ -67,16 +67,13 @@ def test_get_java_version():
     assert not java_version.endswith('"')
 
 
-def test_ran_unpack_apk(decompiler, bad_decompiler):
+def test_ran_unpack_apk(decompiler):
     classes_dex_path = os.path.join(decompiler.build_directory, "classes.dex")
     assert classes_dex_path == decompiler.dex_path
     assert os.path.isfile(classes_dex_path)
 
     shutil.rmtree(decompiler.build_directory)
     assert not os.path.isdir(decompiler.build_directory)
-
-    with pytest.raises(SystemExit):
-        bad_decompiler._unpack_apk()
 
 
 def test_ran_apktool(decompiler):

--- a/tests/test_plugins/test_broadcast_plugins/test_send_broadcast_receiver_permission.py
+++ b/tests/test_plugins/test_broadcast_plugins/test_send_broadcast_receiver_permission.py
@@ -1,8 +1,5 @@
 from qark.plugins.broadcast.send_broadcast_receiver_permission import SendBroadcastReceiverPermission
 
-import os
-import shutil
-
 
 def test_send_broadcast_receiver_permission(vulnerable_broadcast_path):
     plugin = SendBroadcastReceiverPermission()

--- a/tests/test_qark.py
+++ b/tests/test_qark.py
@@ -6,7 +6,7 @@ import os
 import shutil
 
 
-def test_full_sca(path_to_apk, build_directory):
+def test_full_sca(path_to_source, build_directory):
     if os.path.isdir(build_directory):
         shutil.rmtree(build_directory)
     os.environ['LC_ALL'] = 'en_US.utf-8'
@@ -15,7 +15,7 @@ def test_full_sca(path_to_apk, build_directory):
     runner = CliRunner()
 
     # decompile and run scans on goatdroid APK putting output to build_directory
-    result = runner.invoke(cli, ["--apk", path_to_apk, "--build-path", build_directory])
+    result = runner.invoke(cli, ["--apk", path_to_source, "--build-path", build_directory])
     assert 0 == result.exit_code
 
 

--- a/tests/test_qark.py
+++ b/tests/test_qark.py
@@ -24,5 +24,11 @@ def test_full_sca(path_to_apk, build_directory):
     assert 0 == result.exit_code
 
     # scan a file that has an issue
-    result = runner.invoke(cli, ["--java", "build_directory/cfr/android/support/v4/content/LocalBroadcastManager.java"])
+    result = runner.invoke(cli, ["--java", os.path.join(os.path.dirname(os.path.abspath(__file__)), "build_directory",
+                                                        "cfr",
+                                                        "android",
+                                                        "support",
+                                                        "v4",
+                                                        "content",
+                                                        "LocalBroadcastManager.java")])
     assert 0 == result.exit_code

--- a/tests/test_qark.py
+++ b/tests/test_qark.py
@@ -1,0 +1,28 @@
+from click.testing import CliRunner
+
+from qark.qark import cli
+
+import os
+import shutil
+
+
+def test_full_sca(path_to_apk, build_directory):
+    if os.path.isdir(build_directory):
+        shutil.rmtree(build_directory)
+    os.environ['LC_ALL'] = 'en_US.utf-8'
+    os.environ['LANG'] = 'en_US.utf-8'
+
+    runner = CliRunner()
+
+    # decompile and run scans on goatdroid APK putting output to build_directory
+    result = runner.invoke(cli, ["--apk", path_to_apk, "--build-path", build_directory])
+    assert 0 == result.exit_code
+
+
+    # run scans on build directory files
+    result = runner.invoke(cli, ["--java", build_directory])
+    assert 0 == result.exit_code
+
+    # scan a file that has an issue
+    result = runner.invoke(cli, ["--java", "build_directory/cfr/android/support/v4/content/LocalBroadcastManager.java"])
+    assert 0 == result.exit_code

--- a/tests/test_scanner/test_scanner.py
+++ b/tests/test_scanner/test_scanner.py
@@ -4,7 +4,6 @@ import os
 import shutil
 
 
-
 def test_run(scanner, decompiler):
     decompiler.decompile()
 
@@ -13,7 +12,7 @@ def test_run(scanner, decompiler):
     scanner.run()
     assert 0 < len(scanner.issues)
 
-'''
+
 def test_run_manifest_checks(scanner):
     scanner.issues = []
     scanner._run_checks("manifest")
@@ -24,14 +23,14 @@ def test_run_manifest_checks(scanner):
     scanner.issues = []
     scanner._run_checks("manifest")
     assert 7 == len(scanner.issues)
-'''
+
 
 def test_run_broadcast_checks(scanner):
     scanner.issues = []
     scanner._run_checks("broadcast")
     assert 0 < len(scanner.issues)
 
-'''
+
 def test_run_file_checks(scanner):
     scanner.issues = []
     scanner._run_checks("file")
@@ -53,4 +52,3 @@ def test_scanner_singleton(decompiler):
     assert s2 is s1
     assert len(s2.issues) == 1
     assert s2.issues.pop() == "new_issue"
-'''

--- a/tests/test_scanner/test_scanner.py
+++ b/tests/test_scanner/test_scanner.py
@@ -4,12 +4,8 @@ import os
 import shutil
 
 
-def test_run(scanner, build_directory, decompiler):
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
 
-    decompiler._run_dex2jar()
-    decompiler.run_apktool()
+def test_run(scanner, decompiler):
     decompiler.decompile()
 
     scanner.issues = []
@@ -17,34 +13,34 @@ def test_run(scanner, build_directory, decompiler):
     scanner.run()
     assert 0 < len(scanner.issues)
 
-
+'''
 def test_run_manifest_checks(scanner):
     scanner.issues = []
-    scanner._run_manifest_checks()
+    scanner._run_checks("manifest")
     assert 7 == len(scanner.issues)
 
     # this should hit the other code path where
     #   manifest_path is already set
     scanner.issues = []
-    scanner._run_manifest_checks()
+    scanner._run_checks("manifest")
     assert 7 == len(scanner.issues)
-
+'''
 
 def test_run_broadcast_checks(scanner):
     scanner.issues = []
-    scanner._run_broadcast_checks()
-    assert 0 == len(scanner.issues)  # goatdroid not using these methods
+    scanner._run_checks("broadcast")
+    assert 0 < len(scanner.issues)
 
-
+'''
 def test_run_file_checks(scanner):
     scanner.issues = []
-    scanner._run_file_checks()
+    scanner._run_checks("file")
     assert 0 == len(scanner.issues)
-    
-    
+
+
 def test_run_intent_checks(scanner):
     scanner.issues = []
-    scanner._run_intent_checks()
+    scanner._run_checks("intent")
     assert 0 == len(scanner.issues)  # goatdroid doesnt have any of these vulnerabilities
 
 
@@ -57,3 +53,4 @@ def test_scanner_singleton(decompiler):
     assert s2 is s1
     assert len(s2.issues) == 1
     assert s2.issues.pop() == "new_issue"
+'''


### PR DESCRIPTION
Issue #176 

There are a lot of changes that went into making the CLI work. I tried my best to break them into commits, so it might be worthwhile to check the commit messages instead of reviewing all file changes.

Design decisions:

- Scanner has been changed to have a single function that will run checks based on category. This replaces the old way of having it call `_run_manifest_checks`, `_run_intent_checks`, etc.
- Plugins that work only on java files should use helper method `get_java_from_files`
- Report updated to pass `issues` in its constructor
- Some checks for manifest had to be altered to allow for java files only. These checks should return early on once they see that no manifest is available.