### PR TITLE
fix webview helpers to not iterate over NoneType selectors

### DIFF
--- a/qark/plugins/webview/helpers.py
+++ b/qark/plugins/webview/helpers.py
@@ -61,6 +61,9 @@ def webview_default_vulnerable(tree, method_name, issue_name, description, file_
                 webview_name = method_invocation.qualifier
 
                 # selectors are the .operators after the function, in this case `setAllowFileAccess`
+                if method_invocation.selectors is None:
+                    continue
+
                 for selector in method_invocation.selectors:
                     if valid_set_method_bool(method_invocation=selector, str_bool="false", method_name=method_name):
 


### PR DESCRIPTION
Noticed a bug in the testing logs.

Affected in certain circumstances (specific code):

1. `set_allow_file_access`
2. `set_allow_content_access`
3. `set_allow_universal_access_from_file_urls`