### PR TITLE
add plugin blacklisting to scanner.get_plugins

### DIFF
--- a/qark/plugins/webview/helpers.py
+++ b/qark/plugins/webview/helpers.py
@@ -61,6 +61,9 @@ def webview_default_vulnerable(tree, method_name, issue_name, description, file_
                 webview_name = method_invocation.qualifier
 
                 # selectors are the .operators after the function, in this case `setAllowFileAccess`
+                if method_invocation.selectors is None:
+                    continue
+
                 for selector in method_invocation.selectors:
                     if valid_set_method_bool(method_invocation=selector, str_bool="false", method_name=method_name):
 

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -9,6 +9,9 @@ log = logging.getLogger(__name__)
 
 plugin_base = PluginBase(package="qark.custom_plugins")
 
+# plugin modules to blacklist, `helpers` should always be blacklisted as it is not a plugin
+BLACKLISTED_PLUGIN_MODULES = {"helpers"}
+
 
 def get_plugin_source(category=None):
     """
@@ -29,12 +32,15 @@ def get_plugin_source(category=None):
 
 def get_plugins(category=None):
     """
-    Returns all plugins defined by a `category`. TODO: implement blacklisting in this method
+    Returns all plugins defined by a `category` and removes plugins defined in ``BLACKLISTED_PLUGIN_MODULES``.
+
     :param category: plugin category, subdirectory under `plugins/`
     :return: modules for that category
     :rtype: list
     """
-    return get_plugin_source(category=category).list_plugins()
+    plugins = get_plugin_source(category=category).list_plugins()
+
+    return [plugin for plugin in plugins if plugin not in BLACKLISTED_PLUGIN_MODULES]
 
 
 class BasePlugin(object):


### PR DESCRIPTION
Scanner was running against the `helpers` module that isn't a plugin. Therefore, this PR allows blacklisting via module name. In the future we should allow users to pass which modules they want to blacklist via command line or a file.