### PR TITLE
add flyweight pattern to manifest plugins

### DIFF
--- a/qark/plugins/manifest/allow_backup.py
+++ b/qark/plugins/manifest/allow_backup.py
@@ -1,39 +1,32 @@
-from qark.xml_helpers import get_manifest_out_of_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import ManifestPlugin
 from qark.issue import Severity, Issue
 
 import logging
-from xml.dom import minidom
 
 log = logging.getLogger(__name__)
 
 
-class ManifestBackupAllowed(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="Backup is allowed in manifest",
-                            description=("Backups enabled: Potential for data theft via local attacks via adb backup, "
-                                         "if the device has USB debugging enabled (not common). "
-                                         "More info: "
-                                         "http://developer.android.com/reference/android/R.attr.html#allowBackup"))
+class ManifestBackupAllowed(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(dict(category="manifest", name="Backup is allowed in manifest",
+                           description=(
+                               "Backups enabled: Potential for data theft via local attacks via adb "
+                               "backup, if the device has USB debugging enabled (not common). "
+                               "More info: "
+                               "http://developer.android.com/reference/android/R.attr.html#allowBackup")))
+
+        super(ManifestBackupAllowed, self).__init__(**kwargs)
+
         self.severity = Severity.WARNING
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
+        application_sections = self.manifest_xml.getElementsByTagName("application")
 
-        try:
-            manifest_xml = minidom.parse(manifest_path)
-        except Exception:
-            log.exception("Failed to parse manifest file, is it valid syntax?")
-            return  # do not raise a SystemExit because other checks can still be ran
-
-        application_sections = manifest_xml.getElementsByTagName("application")
         for application in application_sections:
             if "android:allowBackup" in application.attributes.keys():
                 self.issues.append(Issue(category=self.category, severity=self.severity,
                                          name=self.name, description=self.description,
-                                         file_object=manifest_path))
+                                         file_object=self.manifest_path))
 
 
 plugin = ManifestBackupAllowed()

--- a/qark/plugins/manifest/custom_permissions.py
+++ b/qark/plugins/manifest/custom_permissions.py
@@ -1,42 +1,33 @@
 from qark.plugins.manifest_helpers import get_min_sdk
-from qark.xml_helpers import get_manifest_out_of_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import ManifestPlugin
 from qark.issue import Severity, Issue
 
 import logging
-from xml.dom import minidom
 
 log = logging.getLogger(__name__)
 
 
-class CustomPermissions(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="Custom permissions are enabled in the manifest",
-                            description=("This permission can be obtained by malicious apps installed prior to this "
-                                         "one, without the proper signature. Applicable to Android Devices prior to "
-                                         "L (Lollipop). More info: "
-                                         "https://github.com/commonsguy/cwac-security/blob/master/PERMS.md"))
+class CustomPermissions(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(dict(category="manifest", name="Custom permissions are enabled in the manifest",
+                           description=("This permission can be obtained by malicious apps installed prior to this "
+                                        "one, without the proper signature. Applicable to Android Devices prior to "
+                                        "L (Lollipop). More info: "
+                                        "https://github.com/commonsguy/cwac-security/blob/master/PERMS.md")))
+
+        super(CustomPermissions, self).__init__(**kwargs)
+
         self.severity = Severity.WARNING
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
-
-        try:
-            manifest_xml = minidom.parse(manifest_path)
-        except Exception:
-            log.exception("Failed to parse manifest file, is it valid syntax?")
-            return  # do not raise a SystemExit because other checks can still be ran
-
-        permission_sections = manifest_xml.getElementsByTagName("permission")
+        permission_sections = self.manifest_xml.getElementsByTagName("permission")
         for permission in permission_sections:
             try:
                 if permission.attributes["android:protectionLevel"].value in ("signature", "signatureOrSystem"):
-                    if apk_constants.get("minimum_sdk", get_min_sdk(manifest_xml)) < 21:
+                    if apk_constants.get("minimum_sdk", get_min_sdk(self.manifest_xml)) < 21:
                         self.issues.append(Issue(category=self.category, severity=self.severity,
                                                  name=self.name, description=self.description,
-                                                 file_object=manifest_path))
+                                                 file_object=self.manifest_path))
 
             except KeyError:
                 continue

--- a/qark/plugins/manifest/debuggable.py
+++ b/qark/plugins/manifest/debuggable.py
@@ -1,43 +1,33 @@
-from qark.xml_helpers import get_manifest_out_of_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import ManifestPlugin
 from qark.issue import Severity, Issue
 
 import logging
-from xml.dom import minidom
 
 log = logging.getLogger(__name__)
 
 
-class DebuggableManifest(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="Manifest is manually set to debug",
-                            description=("The android:debuggable flag is manually set to true in the"
-                                         " AndroidManifest.xml. This will cause your application to be debuggable "
-                                         "in production builds and can result in data leakage "
-                                         "and other security issues. It is not necessary to set the "
-                                         "android:debuggable flag in the manifest, it will be set appropriately "
-                                         "automatically by the tools. More info: "
-                                         "http://developer.android.com/guide/topics/manifest/application-element.html#debug"))
+class DebuggableManifest(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(dict(category="manifest", name="Manifest is manually set to debug",
+                           description=("The android:debuggable flag is manually set to true in the"
+                                        " AndroidManifest.xml. This will cause your application to be debuggable "
+                                        "in production builds and can result in data leakage "
+                                        "and other security issues. It is not necessary to set the "
+                                        "android:debuggable flag in the manifest, it will be set appropriately "
+                                        "automatically by the tools. More info: "
+                                        "http://developer.android.com/guide/topics/manifest/application-element.html#debug")))
+        super(DebuggableManifest, self).__init__(**kwargs)
+
         self.severity = Severity.VULNERABILITY
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
-
-        try:
-            manifest_xml = minidom.parse(manifest_path)
-        except Exception:
-            log.exception("Failed to parse manifest file, is it valid syntax?")
-            return  # do not raise a SystemExit because other checks can still be ran
-
-        application_sections = manifest_xml.getElementsByTagName("application")
+        application_sections = self.manifest_xml.getElementsByTagName("application")
         for application in application_sections:
             try:
                 if application.attributes["android:debuggable"].value.lower() == "true":
                     self.issues.append(Issue(category=self.category, severity=self.severity,
                                              name=self.name, description=self.description,
-                                             file_object=manifest_path))
+                                             file_object=self.manifest_path))
             except (KeyError, AttributeError):
                 log.debug("Application section does not have debuggable flag, continuing")
                 continue

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -8,6 +8,7 @@ from os import (
 
 from qark.plugins.manifest_helpers import get_min_sdk, get_target_sdk
 from qark.scanner.plugin import get_plugin_source, get_plugins
+from qark.scanner.plugin import ManifestPlugin
 
 log = logging.getLogger(__name__)
 
@@ -28,6 +29,10 @@ class Scanner(object):
         self.files = set()
         self.issues = []
         self.manifest_path = manifest_path
+
+        # Manifest plugins should be able to retrieve the manifest xml directly
+        ManifestPlugin.update_manifest(manifest_path)
+
         self.path_to_source = path_to_source
         self.build_directory = build_directory
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,12 @@ def decompiler(path_to_source, build_directory):
     return Decompiler(path_to_source=path_to_source, build_directory=build_directory)
 
 
+@pytest.fixture(scope="module")
+def module_decompiler(path_to_source, build_directory):
+    return Decompiler(path_to_source=path_to_source, build_directory=build_directory)
+
+
+
 @pytest.fixture()
 def scanner(decompiler):
     return Scanner(decompiler.manifest_path, decompiler.path_to_source, decompiler.build_directory)

--- a/tests/test_plugins/test_manifest_plugins/test_manifest_plugins.py
+++ b/tests/test_plugins/test_manifest_plugins/test_manifest_plugins.py
@@ -1,82 +1,80 @@
 import os
 import shutil
+from xml.dom import minidom
 
 import pytest
 
 from qark.issue import Severity
-from qark.scanner.scanner import Scanner
 from qark.plugins.manifest.allow_backup import ManifestBackupAllowed
 from qark.plugins.manifest.custom_permissions import CustomPermissions
 from qark.plugins.manifest.debuggable import DebuggableManifest
 from qark.plugins.manifest.exported_tags import ExportedTags
 from qark.plugins.manifest.min_sdk import MinSDK, TAP_JACKING
+from qark.scanner.plugin import ManifestPlugin
 
 
-def test_allow_backup(decompiler, build_directory, vulnerable_manifest_path):
-    # set the path to manifest file
+@pytest.fixture(scope="module")
+def test_android_manifest(vulnerable_manifest_path):
+    return minidom.parse(vulnerable_manifest_path)
+
+
+@pytest.fixture(scope="module")
+def goatdroid_manifest(module_decompiler, build_directory):
     if os.path.isdir(build_directory):
         shutil.rmtree(build_directory)
 
-    plugin = ManifestBackupAllowed()
-    plugin.run([vulnerable_manifest_path], apk_constants={})
+    return minidom.parse(module_decompiler.run_apktool())
+
+
+def test_vulnerable_allow_backup(test_android_manifest):
+    plugin = ManifestBackupAllowed(manifest_xml=test_android_manifest)
+    plugin.run([], apk_constants={})
     assert len(plugin.issues) == 1
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
     assert plugin.issues[0].category == plugin.category
 
-    decompiler.manifest_path = decompiler.run_apktool()
-    plugin = ManifestBackupAllowed()
-    plugin.run([decompiler.manifest_path], apk_constants={})
+
+def test_nonvulnerable_allow_backup(goatdroid_manifest):
+    plugin = ManifestBackupAllowed(manifest_xml=goatdroid_manifest)
+    plugin.run([], apk_constants={})
     assert len(plugin.issues) == 0  # non vulnerable manifest
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
 
 
-def test_custom_permission(decompiler, build_directory, vulnerable_manifest_path):
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
-
-    plugin = CustomPermissions()
-    plugin.run([vulnerable_manifest_path], apk_constants={})
+def test_custom_permission_vulnerable(test_android_manifest):
+    plugin = CustomPermissions(manifest_xml=test_android_manifest)
+    plugin.run([], apk_constants={})
     assert len(plugin.issues) == 1
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
     assert plugin.issues[0].category == plugin.category
 
-    decompiler.manifest_path = decompiler.run_apktool()
-    plugin = CustomPermissions()
-    plugin.run([decompiler.manifest_path], apk_constants={})
-    assert len(plugin.issues) == 0  # non vulnerable manifest
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
 
-
-def test_debuggable(decompiler, build_directory, vulnerable_manifest_path):
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
-    # the goatdroid manifest is vulnerable. Run it on a non-vulnerable one
-    plugin = DebuggableManifest()
-    plugin.run([vulnerable_manifest_path], apk_constants={})
+def test_custom_permission_nonvulnerable(goatdroid_manifest):
+    plugin = CustomPermissions(manifest_xml=goatdroid_manifest)
+    plugin.run([], apk_constants={})
     assert len(plugin.issues) == 0
 
-    decompiler.manifest_path = decompiler.run_apktool()
-    plugin = DebuggableManifest()
-    plugin.run([decompiler.manifest_path], apk_constants={})
+
+def test_debuggable_nonvulnerable(test_android_manifest):
+    plugin = DebuggableManifest(manifest_xml=test_android_manifest)
+    plugin.run([], apk_constants={})
+    assert len(plugin.issues) == 0
+
+
+def test_debuggable_vulnerable(goatdroid_manifest):
+    plugin = DebuggableManifest(manifest_xml=goatdroid_manifest)
+    plugin.run([], apk_constants={})
     assert len(plugin.issues) == 1  # vulnerable manifest
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
     assert plugin.issues[0].category == plugin.category
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
 
 
-def test_exported_tags(vulnerable_manifest_path, vulnerable_receiver_path):
+def test_vulnerable_exported_tags(vulnerable_manifest_path, vulnerable_receiver_path):
+    ManifestPlugin.update_manifest(vulnerable_manifest_path)
     plugin = ExportedTags()
-    scanner = Scanner(manifest_path=vulnerable_manifest_path,
-                      path_to_source="/Users/nwalsh/IdeaProjects/qark/build/qark",
-                      build_directory="/Users/nwalsh/IdeaProjects/qark/build/qark")
-    scanner.run()
-    plugin.run([vulnerable_manifest_path, vulnerable_receiver_path], apk_constants={})
+    plugin.run([vulnerable_receiver_path], apk_constants={})
     assert len(plugin.issues) == 6
     for issue in plugin.issues:
         assert Severity.WARNING == issue.severity
@@ -88,12 +86,12 @@ def test_exported_tags(vulnerable_manifest_path, vulnerable_receiver_path):
     {"min_sdk": 8},
     {},
 ])
-def test_min_sdk(apk_constants):
+def test_vulnerable_min_sdk(apk_constants):
+    ManifestPlugin.update_manifest(os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                                "test_min_sdk_tapjacking",
+                                                "androidmanifest.xml"))
     plugin = MinSDK()
-    plugin.run([os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                             "test_min_sdk_tapjacking",
-                             "androidmanifest.xml")],
-               apk_constants=apk_constants)
+    plugin.run([], apk_constants=apk_constants)
     assert 1 == len(plugin.issues)
     for issue in plugin.issues:
         assert Severity.VULNERABILITY == issue.severity


### PR DESCRIPTION
Creates a class `ManifestPlugin` that contains two class attributes:

1. manifest_path
2. manifest_xml

All manifest plugins should use these to get details about the manifest. Sharing this information allows us to clean code (don't need to parse manifest in each plugin) and to share memory between plugins.