### PR TITLE
Test/fix dynamic broadcast receiver

### DIFF
--- a/tests/test_java_files/dynamic_broadcast_receiver.java
+++ b/tests/test_java_files/dynamic_broadcast_receiver.java
@@ -1,0 +1,8 @@
+class RegisterReceiver {
+  public void Test(Context context, Calendar c) {
+    final String SOME_ACTION = "com.android.action.MyAction.SomeAction";
+    IntentFilter intentFilter = new IntentFilter(SOME_ACTION);
+    Receiver mReceiver = new Receiver();
+    context.registerReceiver(mReceiver, intentFilter);
+  }
+}

--- a/tests/test_plugins/test_broadcast_plugins/test_dynamic_broadcast_receiver.py
+++ b/tests/test_plugins/test_broadcast_plugins/test_dynamic_broadcast_receiver.py
@@ -1,0 +1,25 @@
+import os
+
+from qark.plugins.broadcast.dynamic_broadcast_receiver import DynamicBroadcastReceiver
+
+
+def test_vulnerable_dynamic_broadcast_receiver(test_java_files):
+    plugin = DynamicBroadcastReceiver()
+    plugin.run(files=[os.path.join(test_java_files,
+                                   "dynamic_broadcast_receiver.java")],
+               apk_constants={"min_sdk": 5})
+
+    assert len(plugin.issues) == 1  # vulnerable manifest
+    assert plugin.issues[0].name == plugin.name
+    assert plugin.issues[0].severity == plugin.severity
+    assert plugin.issues[0].category == plugin.category
+
+
+def test_nonvulnerable_dynamic_broadcast_receiver(test_java_files):
+    plugin = DynamicBroadcastReceiver()
+    plugin.run(files=[os.path.join(test_java_files,
+                                   "dynamic_broadcast_receiver.java")],
+               apk_constants={"min_sdk": 14})
+
+    assert len(plugin.issues) == 0
+


### PR DESCRIPTION
Previous check (in QARK v1) was checking for a method declared as `registerReceiver` when it should have been checking `Invocation`.