### PR TITLE
fix/test for android logging

### DIFF
--- a/qark/plugins/file/android_logging.py
+++ b/qark/plugins/file/android_logging.py
@@ -1,7 +1,13 @@
 """
-Checks if either a method with name "d" or "v" is invoked. For instance:
+Checks if either a method within ``ANDROID_LOGGING_METHODS`` is invoked with `Log.` before it.
 
-Log.d("test") would trigger, as would d("test").
+For instance:
+Log.d("test")
+Log.e("test")
+
+Both trigger but the following does not:
+d("test")
+e("test")
 """
 
 import logging
@@ -21,8 +27,7 @@ ANDROID_LOGGING_DESCRIPTION = (
     "https://developer.android.com/reference/android/util/Log.html"
 )
 
-VERBOSE_LOG_METHOD_NAME = "v"
-DEBUG_LOG_METHOD_NAME = "d"
+ANDROID_LOGGING_METHODS = ("v", "d", "i", "w", "e")
 
 
 class AndroidLogging(BasePlugin):
@@ -52,12 +57,12 @@ class AndroidLogging(BasePlugin):
             return
 
         for _, method_invocation in tree.filter(MethodInvocation):
-            if method_invocation.member in (VERBOSE_LOG_METHOD_NAME, DEBUG_LOG_METHOD_NAME):
+            if method_invocation.qualifier == "Log" and method_invocation.member in ANDROID_LOGGING_METHODS:
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,
                     description=self.description,
                     file_object=java_file,
-                    line_number=method_invocation.pos)
+                    line_number=method_invocation.position)
                 )
 
 

--- a/tests/test_java_files/test_android_logging.java
+++ b/tests/test_java_files/test_android_logging.java
@@ -1,0 +1,10 @@
+class Test {
+  public void Test() {
+    Log.d("test");
+    Log.v("test");
+  }
+  public void Test2() {
+    d("test");
+    v("test");
+  }
+}

--- a/tests/test_plugins/test_file_plugins/test_file_plugins.py
+++ b/tests/test_plugins/test_file_plugins/test_file_plugins.py
@@ -1,4 +1,5 @@
 from qark.plugins.file.file_permissions import FilePermissions, WORLD_READABLE_DESCRIPTION, WORLD_WRITEABLE_DESCRIPTION
+from qark.plugins.file.android_logging import AndroidLogging
 from qark.issue import Severity
 
 import os
@@ -16,3 +17,12 @@ def test_file_permissions():
     assert Severity.WARNING == plugin.issues[1].severity
     assert WORLD_WRITEABLE_DESCRIPTION == plugin.issues[1].description
 
+
+def test_android_logging(test_java_files):
+    plugin = AndroidLogging()
+    plugin.run([os.path.join(test_java_files,
+                             "test_android_logging.java")])
+    assert 2 == len(plugin.issues)
+    assert plugin.issues[0].name == plugin.name
+    assert plugin.issues[0].severity == plugin.severity
+    assert plugin.issues[0].category == plugin.category


### PR DESCRIPTION
The v1 check was just checking for methods `d`, `v` etc. This updates it to check that it is `Log.d` or `Log.v`.