### PR TITLE
add travis_wait for long running pytest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 install:
   - pip install -r requirements-test.txt
 script:
-  - python -m pytest
+  - travis_wait python -m pytest


### PR DESCRIPTION
Should allow us to execute our long running scanner / decompiling tests.