### PR TITLE
test/fix external storage

### DIFF
--- a/qark/plugins/file/external_storage.py
+++ b/qark/plugins/file/external_storage.py
@@ -1,3 +1,13 @@
+"""
+This plugin determines if the following methods are called:
+
+1. getExternalFilesDir
+2. getExternalFilesDirs
+3. getExternalMediaDirs
+4. getExternalStoragePublicDirectory
+
+"""
+
 import logging
 
 import javalang
@@ -17,6 +27,7 @@ EXTERNAL_STORAGE_DESCRIPTION = (
 )
 
 EXTERNAL_FILES_DIR_METHOD = 'getExternalFilesDir'
+EXTERNAL_FILES_DIRS_METHOD = 'getExternalFilesDirs'
 EXTERNAL_MEDIA_DIR_METHOD = 'getExternalMediaDirs'
 EXTERNAL_STORAGE_PUBLIC_DIR_METHOD = 'getExternalStoragePublicDirectory'
 
@@ -47,23 +58,23 @@ class ExternalStorage(BasePlugin):
             log.debug("Error parsing file %s, continuing", java_file)
             return
 
-        if any(["File" in imp for imp in tree.imports]):
-            for _, method_invocation in tree.filter(MethodInvocation):
-                storage_location = None
-                if method_invocation.member == EXTERNAL_FILES_DIR_METHOD:
-                    storage_location = "External Storage"
-                elif method_invocation.member == EXTERNAL_MEDIA_DIR_METHOD:
-                    storage_location = "External Media Directory"
-                elif method_invocation.member == EXTERNAL_STORAGE_PUBLIC_DIR_METHOD:
-                    storage_location = "External Storage Public Directory"
+        for _, method_invocation in tree.filter(MethodInvocation):
+            storage_location = None
+            if (method_invocation.member == EXTERNAL_FILES_DIR_METHOD
+                    or method_invocation.member == EXTERNAL_FILES_DIRS_METHOD):
+                storage_location = "External Storage"
+            elif method_invocation.member == EXTERNAL_MEDIA_DIR_METHOD:
+                storage_location = "External Media Directory"
+            elif method_invocation.member == EXTERNAL_STORAGE_PUBLIC_DIR_METHOD:
+                storage_location = "External Storage Public Directory"
 
-                if storage_location:
-                    self.issues.append(Issue(
-                        category=self.category, severity=self.severity, name=self.name,
-                        description=self.description,
-                        file_object=java_file,
-                        line_number=method_invocation.pos)
-                    )
+            if storage_location:
+                self.issues.append(Issue(
+                    category=self.category, severity=self.severity, name=self.name,
+                    description=self.description,
+                    file_object=java_file,
+                    line_number=method_invocation.position)
+                )
 
 
 plugin = ExternalStorage()

--- a/tests/test_java_files/external_storage.java
+++ b/tests/test_java_files/external_storage.java
@@ -1,0 +1,9 @@
+class Test {
+  public static File[] Test(Context context) {
+    File[] roots = context.getExternalFilesDirs("external");
+    File roots = context.getExternalFilesDir("external");
+    File roots = context.getExternalMediaDirs("external");
+    File roots = context.getExternalStoragePublicDirectory("external");
+    return roots;
+  }
+}

--- a/tests/test_plugins/test_file_plugins/test_file_plugins.py
+++ b/tests/test_plugins/test_file_plugins/test_file_plugins.py
@@ -1,4 +1,5 @@
 from qark.plugins.file.file_permissions import FilePermissions, WORLD_READABLE_DESCRIPTION, WORLD_WRITEABLE_DESCRIPTION
+from qark.plugins.file.external_storage import ExternalStorage
 from qark.issue import Severity
 
 import os
@@ -16,3 +17,9 @@ def test_file_permissions():
     assert Severity.WARNING == plugin.issues[1].severity
     assert WORLD_WRITEABLE_DESCRIPTION == plugin.issues[1].description
 
+
+def test_external_storage(test_java_files):
+    plugin = ExternalStorage()
+    plugin.run([os.path.join(test_java_files,
+                             "external_storage.java")])
+    assert 4 == len(plugin.issues)


### PR DESCRIPTION
Removes the previous check that `File` was in the imports. I feel that the method calls are specific enough the reduce false positives.