### PR TITLE
convert manifest plugins and add tests

### DIFF
--- a/qark/plugins/manifest/android_path.py
+++ b/qark/plugins/manifest/android_path.py
@@ -1,8 +1,7 @@
 import logging
 
 from qark.issue import Severity, Issue
-from qark.scanner.plugin import BasePlugin
-from qark.xml_helpers import get_manifest_out_of_files
+from qark.scanner.plugin import ManifestPlugin
 
 log = logging.getLogger(__name__)
 
@@ -10,24 +9,20 @@ PATH_USAGE_DESCRIPTION = ("android:path means that the permission applies to the
                           " in android:path. This expression does not protect the sub-directories")
 
 
-class AndroidPath(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="android:path tag used",
-                            description=PATH_USAGE_DESCRIPTION)
+class AndroidPath(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(category="manifest", name="android:path tag used", description=PATH_USAGE_DESCRIPTION)
+        super(AndroidPath, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
-
-        with open(manifest_path, "r") as manifest_file:
+        with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 if "android:path=" in line:
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=manifest_path,
+                        file_object=self.manifest_path,
                         line_number=line_number)
                     )
 

--- a/qark/plugins/manifest/api_keys.py
+++ b/qark/plugins/manifest/api_keys.py
@@ -2,43 +2,39 @@ import logging
 import re
 
 from qark.issue import Severity, Issue
-from qark.scanner.plugin import BasePlugin
-from qark.xml_helpers import get_manifest_out_of_files
+from qark.scanner.plugin import ManifestPlugin
 
 log = logging.getLogger(__name__)
 
 API_KEY_REGEX = re.compile(r'(?=.{20,})(?=.+\d)(?=.+[a-z])(?=.+[A-Z])')
 SPECIAL_CHARACTER_REGEX = re.compile(r'(?=.+[!$%^~])')
-HARDCODED_API_KEY_REGEX = re.compile(r'API_KEY|api_key|API|api|key')
+HARDCODED_API_KEY_REGEX = re.compile(r'api_key|api|key', re.IGNORECASE)
 
-API_KEY_DESCRIPTION = "Please confirm and investigate the API key to determine its severity."
+API_KEY_DESCRIPTION = "Please confirm and investigate for potential API keys to determine severity."
 
 
-class APIKeys(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="Potential API Key found",
-                            description=API_KEY_DESCRIPTION)
+class APIKeys(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(category="manifest", name="Potential API Key found", description=API_KEY_DESCRIPTION)
+        super(APIKeys, self).__init__(**kwargs)
         self.severity = Severity.INFO
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
-
-        with open(manifest_path, "r") as manifest_file:
+        with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
-                if re.search(API_KEY_REGEX, line) and not re.search(SPECIAL_CHARACTER_REGEX, line):
+                # TODO: Fix API_KEY_REGEX, there are too many false positives
+                # if re.search(API_KEY_REGEX, line) and not re.search(SPECIAL_CHARACTER_REGEX, line):
+                #     self.issues.append(Issue(
+                #         category=self.category, severity=self.severity, name=self.name,
+                #         description=self.description,
+                #         file_object=self.manifest_path,
+                #         line_number=line_number)
+                #     )
+                if re.search(HARDCODED_API_KEY_REGEX, line):
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=manifest_path,
-                        line_number=line_number)
-                    )
-                elif re.search(HARDCODED_API_KEY_REGEX, line):
-                    self.issues.append(Issue(
-                        category=self.category, severity=self.severity, name=self.name,
-                        description=self.description,
-                        file_object=manifest_path,
+                        file_object=self.manifest_path,
                         line_number=line_number)
                     )
 

--- a/qark/plugins/manifest/single_task_launch_mode.py
+++ b/qark/plugins/manifest/single_task_launch_mode.py
@@ -1,7 +1,7 @@
 import logging
 
 from qark.issue import Severity, Issue
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import ManifestPlugin
 from qark.xml_helpers import get_manifest_out_of_files
 
 log = logging.getLogger(__name__)
@@ -13,24 +13,20 @@ TASK_LAUNCH_MODE_DESCRIPTION = (
 )
 
 
-class SingleTaskLaunchMode(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="launchMode=singleTask found",
-                            description=TASK_LAUNCH_MODE_DESCRIPTION)
+class SingleTaskLaunchMode(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(category="manifest", name="launchMode=singleTask found", description=TASK_LAUNCH_MODE_DESCRIPTION)
+        super(SingleTaskLaunchMode, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
-
-        with open(manifest_path, "r") as manifest_file:
+        with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 if 'android:launchMode="singleTask"' in line:
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=manifest_path,
+                        file_object=self.manifest_path,
                         line_number=line_number)
                     )
 

--- a/qark/plugins/manifest/task_reparenting.py
+++ b/qark/plugins/manifest/task_reparenting.py
@@ -1,8 +1,7 @@
 import logging
 
 from qark.issue import Severity, Issue
-from qark.scanner.plugin import BasePlugin
-from qark.xml_helpers import get_manifest_out_of_files
+from qark.scanner.plugin import ManifestPlugin
 
 log = logging.getLogger(__name__)
 
@@ -13,24 +12,21 @@ TASK_REPARENTING_DESCRIPTION = (
 )
 
 
-class TaskReparenting(BasePlugin):
-    def __init__(self):
-        BasePlugin.__init__(self, category="manifest", name="android:allowTaskReparenting='true' found",
-                            description=TASK_REPARENTING_DESCRIPTION)
+class TaskReparenting(ManifestPlugin):
+    def __init__(self, **kwargs):
+        kwargs.update(category="manifest", name="android:allowTaskReparenting='true' found",
+                      description=TASK_REPARENTING_DESCRIPTION)
+        super(TaskReparenting, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
     def run(self, files, apk_constants=None):
-        manifest_path = get_manifest_out_of_files(files)
-        if not manifest_path:
-            return
-
-        with open(manifest_path, "r") as manifest_file:
+        with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 if 'android:allowTaskReparenting="true"' in line:
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=manifest_path,
+                        file_object=self.manifest_path,
                         line_number=line_number)
                     )
 

--- a/tests/test_plugins/test_manifest_plugins/test_manifest_plugins.py
+++ b/tests/test_plugins/test_manifest_plugins/test_manifest_plugins.py
@@ -10,6 +10,10 @@ from qark.plugins.manifest.custom_permissions import CustomPermissions
 from qark.plugins.manifest.debuggable import DebuggableManifest
 from qark.plugins.manifest.exported_tags import ExportedTags
 from qark.plugins.manifest.min_sdk import MinSDK, TAP_JACKING
+from qark.plugins.manifest.android_path import AndroidPath
+from qark.plugins.manifest.api_keys import APIKeys
+from qark.plugins.manifest.single_task_launch_mode import SingleTaskLaunchMode
+from qark.plugins.manifest.task_reparenting import TaskReparenting
 from qark.scanner.plugin import ManifestPlugin
 
 
@@ -44,7 +48,7 @@ def test_nonvulnerable_allow_backup(goatdroid_manifest):
 def test_custom_permission_vulnerable(test_android_manifest):
     plugin = CustomPermissions(manifest_xml=test_android_manifest)
     plugin.run([], apk_constants={})
-    assert len(plugin.issues) == 1
+    assert len(plugin.issues) == 2
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity
     assert plugin.issues[0].category == plugin.category
@@ -98,3 +102,31 @@ def test_vulnerable_min_sdk(apk_constants):
         assert "Tap Jacking possible" == issue.name
         assert TAP_JACKING == issue.description
         assert plugin.category == issue.category
+
+
+def test_android_path(vulnerable_manifest_path):
+    ManifestPlugin.update_manifest(vulnerable_manifest_path)
+    plugin = AndroidPath()
+    plugin.run([])
+    assert 1 == len(plugin.issues)
+
+
+def test_api_keys(vulnerable_manifest_path):
+    ManifestPlugin.update_manifest(vulnerable_manifest_path)
+    plugin = APIKeys()
+    plugin.run([])
+    assert 1 == len(plugin.issues)
+
+
+def test_single_task_launch_mode(vulnerable_manifest_path):
+    ManifestPlugin.update_manifest(vulnerable_manifest_path)
+    plugin = SingleTaskLaunchMode()
+    plugin.run([])
+    assert 1 == len(plugin.issues)
+
+
+def test_task_reparenting(vulnerable_manifest_path):
+    ManifestPlugin.update_manifest(vulnerable_manifest_path)
+    plugin = TaskReparenting()
+    plugin.run([])
+    assert 1 == len(plugin.issues)

--- a/tests/test_xml_files/test_androidmanifest.xml
+++ b/tests/test_xml_files/test_androidmanifest.xml
@@ -7,10 +7,11 @@
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
         <category android:name="android.intent.category.LAUNCHER" />
+        <data android:path="test"/>
       </intent-filter>
     </activity>
-    <activity android:label="@string/login" android:name=".activities.Login" />
-    <activity android:label="@string/register" android:name=".activities.Register" />
+    <activity android:label="@string/login" android:name=".activities.Login" android:launchMode="singleTask"/>
+    <activity android:label="@string/register" android:name=".activities.Register" android:allowTaskReparenting="true"/>
     <activity android:label="@string/home" android:name=".activities.Home" />
     <activity android:label="@string/checkin" android:name=".fragments.DoCheckin" />
     <activity android:label="@string/checkins" android:name=".activities.Checkins" />
@@ -66,5 +67,5 @@
               android:label="@string/permlab_deadlyActivity"
               android:description="@string/permdesc_deadlyActivity"
               android:permissionGroup="android.permission-group.COST_MONEY"
-              android:protectionLevel="test" />
+              android:protectionLevel="dangerous" />
 </manifest>


### PR DESCRIPTION
Change plugins to inherit from `ManifestPlugin`. Removes the checks for `API_KEY` as it was too permissive. Creating issue on cleaning up that regex.