### PR TITLE
Windows compatiable changes and fix logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: python
+os:
+  - linux
+  - osx
 python:
   - "2.7"
   - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 language: python
-os:
-  - linux
-  - osx
 python:
   - "2.7"
   - "3.6"

--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -36,7 +36,7 @@ DEX2JAR_COMMAND = "{dex2jar_path} {path_to_dex} -o {build_apk}.jar"
 
 
 def escape_windows_path(path):
-    if "\\" in path:
+    if "\\" in path and OS == "Windows":
         try:
             path = path.encode('string-escape')
         except Exception:
@@ -221,7 +221,6 @@ class Decompiler(object):
                 log.critical("Error running dex2jar command: %s", dex2jar_command)
                 raise SystemExit("Error running dex2jar")
         except Exception as e:
-            print(e)
             log.exception("Error running dex2jar command: %s", dex2jar_command)
             raise SystemExit("Error running dex2jar command")
 
@@ -284,7 +283,7 @@ def download_apktool():
     log.debug("Creating directory to store apktool files")
     apktool_path = os.path.join(APK_TOOL_PATH, user_os)
     if not os.path.exists(apktool_path):
-        log.debug("Directory at %s does not exist, creating one")
+        log.debug("Directory at %s does not exist, creating one", apktool_path)
         os.makedirs(apktool_path)
     else:
         log.debug("Directory already exists")
@@ -339,6 +338,7 @@ def download_file(url, download_path):
         os.makedirs(os.path.dirname(download_path))
     except Exception:
         # Directory already exists, continue
+        log.debug("Directory %s already exists for file download %s", download_path, url)
         pass
 
     with open(download_path, "wb") as download_path_file:

--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -26,7 +26,7 @@ DEX2JAR_NAME = DEX2JAR_URL.replace("/download", "").split("/")[-1].rsplit(".zip"
 DEX2JAR_PATH = os.path.join(LIB_PATH, DEX2JAR_NAME)
 DEX2JAR_EXTENSION = "sh" if OS != "Windows" else "bat"
 DEX2JAR_EXECUTABLE = "d2j-dex2jar.{extension}".format(extension=DEX2JAR_EXTENSION)
-DEX2JAR_INVOKE = "d2j-invoke.{extension}".format(extension=DEX2JAR_EXTENSION)
+DEX2JAR_INVOKE = "d2j_invoke.{extension}".format(extension=DEX2JAR_EXTENSION)
 
 DECOMPILERS_PATH = os.path.join(LIB_PATH, "decompilers")
 
@@ -282,9 +282,11 @@ def download_apktool():
     # create directory for operating system
     log.debug("Creating directory to store apktool files")
     apktool_path = os.path.join(APK_TOOL_PATH, user_os)
+
     if not os.path.exists(apktool_path):
         log.debug("Directory at %s does not exist, creating one", apktool_path)
         os.makedirs(apktool_path)
+
     else:
         log.debug("Directory already exists")
         if (os.path.isfile(os.path.join(apktool_path, OS_TO_FILE_NAME[user_os]))
@@ -339,7 +341,6 @@ def download_file(url, download_path):
     except Exception:
         # Directory already exists, continue
         log.debug("Directory %s already exists for file download %s", download_path, url)
-        pass
 
     with open(download_path, "wb") as download_path_file:
         download_path_file.write(response.content)
@@ -386,7 +387,7 @@ def download_procyon():
 
 
 def download_dex2jar():
-    if os.path.isfile(os.path.join(DEX2JAR_PATH, "d2j-dex2jar.{extension}".format(extension=DEX2JAR_EXTENSION))):
+    if os.path.isfile(os.path.join(DEX2JAR_PATH, DEX2JAR_EXECUTABLE)):
         return
 
     try:

--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -220,7 +220,7 @@ class Decompiler(object):
             if ret_code != 0:
                 log.critical("Error running dex2jar command: %s", dex2jar_command)
                 raise SystemExit("Error running dex2jar")
-        except Exception as e:
+        except Exception:
             log.exception("Error running dex2jar command: %s", dex2jar_command)
             raise SystemExit("Error running dex2jar command")
 

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -14,6 +14,8 @@ from qark.scanner.scanner import Scanner
 DEBUG_LOG_PATH = os.path.join(os.getcwd(),
                               "qark_debug.log")
 
+logger = logging.getLogger(__name__)
+
 
 @click.command()
 @click.option("--sdk-path", type=click.Path(exists=True, file_okay=False, resolve_path=True),
@@ -112,3 +114,6 @@ def initialize_logging(level):
             }
         }
     })
+
+    if level == "DEBUG":
+        logger.debug("Debug logging enabled")

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -2,9 +2,9 @@ from __future__ import absolute_import
 
 import logging
 import logging.config
-import os
 
 import click
+import os
 
 from qark.apk_builder import APKBuilder
 from qark.decompiler.decompiler import Decompiler
@@ -77,6 +77,24 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk):
 
 def initialize_logging(level):
     """Creates two root handlers, one to file called `qark_debug.log` and one to stderr"""
+    handlers = {
+        "stderr_handler": {
+            "level": level,
+            "class": "logging.StreamHandler"
+        }
+    }
+    loggers = ["stderr_handler"]
+
+    if level == logging.DEBUG:
+        handlers["debug_handler"] = {
+            "level": "DEBUG",
+            "class": "logging.FileHandler",
+            "filename": DEBUG_LOG_PATH,
+            "mode": "w",
+            "formatter": "standard"
+        }
+        loggers.append("debug_handler")
+
     logging.config.dictConfig({
         "version": 1,
         "disable_existing_loggers": False,
@@ -85,22 +103,10 @@ def initialize_logging(level):
                 'format': '%(asctime)s [%(levelname)s] %(name)s: %(message)s'
             }
         },
-        "handlers": {
-            "debug_handler": {
-                "level": "DEBUG",
-                "class": "logging.FileHandler",
-                "filename": DEBUG_LOG_PATH,
-                "mode": "w",
-                "formatter": "standard"
-            },
-            "stderr_handler": {
-                "level": level,
-                "class": "logging.StreamHandler"
-            }
-        },
+        "handlers": handlers,
         "loggers": {
             "": {
-                "handlers": ["debug_handler", "stderr_handler"],
+                "handlers": handlers,
                 "level": "DEBUG",
                 "propagate": True
             }

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -85,7 +85,7 @@ def initialize_logging(level):
     }
     loggers = ["stderr_handler"]
 
-    if level == logging.DEBUG:
+    if level == "DEBUG":
         handlers["debug_handler"] = {
             "level": "DEBUG",
             "class": "logging.FileHandler",

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -57,18 +57,22 @@ class Scanner(object):
             min_sdk = target_sdk = 1
 
         for plugin_name in get_plugins(category=category):
+            log.debug("Loading plugin %s", plugin_name)
             try:
                 plugin = plugin_source.load_plugin(plugin_name).plugin
             except Exception:
                 log.exception("Error loading plugin %s... continuing with next plugin", plugin_name)
                 continue
 
+            log.debug("Running plugin %s", plugin_name)
             try:
                 plugin.run(files=self.files, apk_constants={"min_sdk": min_sdk,
                                                             "target_sdk": target_sdk})
             except Exception:
                 log.exception("Error running plugin %s... continuing with next plugin", plugin_name)
                 continue
+
+            log.debug("%s finished execution", plugin_name)
 
             self.issues.extend(plugin.issues)
 


### PR DESCRIPTION
Allows operation for Windows with a few changes to `dex2jar` execution by changing file extensions (`sh` for *nix, and `bat` for windows`).

Adds some extra escaping for windows paths which I have had trouble with `subprocess` working with `os.path` properly. 

Fixes the logging modules, and makes the debug log output to the users current directory. I think this can be changed to a configurable value in the future.