### PR TITLE
simple dedupe on report generation and minor fixes

### DIFF
--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -64,8 +64,6 @@ class Decompiler(object):
 
         self.path_to_source = path_to_source
         self.build_directory = os.path.join(build_directory, "qark") if build_directory else os.path.join(os.path.dirname(os.path.abspath(path_to_source)), "qark")
-        if os.path.exists(self.build_directory):
-            shutil.rmtree(self.build_directory)
 
         # validate we are running on an APK, Directory, or Java source code
         if os.path.isfile(self.path_to_source) and os.path.splitext(self.path_to_source.lower())[1] not in (".java",

--- a/qark/issue.py
+++ b/qark/issue.py
@@ -46,9 +46,12 @@ class Issue(object):
 
     def __repr__(self):
         return ("Issue(category={}, name={}, severity={}, description={}, line_number={}, "
-                "file_object={}, apk_exploit_dict={}".format(self.category, self.name, self.severity,
-                                                             self.description, self.line_number, self.file_object,
-                                                             self.apk_exploit_dict))
+                "file_object={}, apk_exploit_dict={})".format(self.category, self.name, self.severity,
+                                                              self.description, self.line_number, self.file_object,
+                                                              self.apk_exploit_dict))
+
+    def __hash__(self):
+        return hash((self.name, self.file_object, self.line_number))
 
 
 class Severity(Enum):

--- a/qark/plugins/file/android_logging.py
+++ b/qark/plugins/file/android_logging.py
@@ -32,7 +32,7 @@ ANDROID_LOGGING_METHODS = ("v", "d", "i", "w", "e")
 
 class AndroidLogging(BasePlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="External storage used",
+        BasePlugin.__init__(self, category="file", name="Logging found",
                             description=ANDROID_LOGGING_DESCRIPTION)
         self.severity = Severity.WARNING
 

--- a/qark/plugins/generic/task_affinity.py
+++ b/qark/plugins/generic/task_affinity.py
@@ -52,11 +52,12 @@ class TaskAffinity(BasePlugin):
             elif re.search(MULTIPLE_TASK_REGEX, file_contents):
                 description = TASK_AFFINITY_DESCRIPTION.format("MULTIPLE")
 
-            self.issues.append(Issue(category=self.category,
-                                     severity=self.severity,
-                                     name=self.name,
-                                     description=description,
-                                     file_object=java_file))
+            if description:
+                self.issues.append(Issue(category=self.category,
+                                         severity=self.severity,
+                                         name=self.name,
+                                         description=description,
+                                         file_object=java_file))
 
 
 plugin = TaskAffinity()

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -19,7 +19,8 @@ logger = logging.getLogger(__name__)
 
 @click.command()
 @click.option("--sdk-path", type=click.Path(exists=True, file_okay=False, resolve_path=True),
-              help="Path to the downloaded SDK directory if already downloaded")
+              help="Path to the downloaded SDK directory if already downloaded. "
+                   "Only necessary if --exploit-apk is passed.")
 @click.option("--build-path", type=click.Path(resolve_path=True, file_okay=False),
               help="Path to place decompiled files and exploit APK", default="build", show_default=True)
 @click.option("--debug/--no-debug", default=False, help="Show debugging statements (helpful for issues)",
@@ -65,7 +66,7 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk):
     click.secho("Finish scans...")
 
     click.secho("Writing report...")
-    report = Report(issues=scanner.issues)
+    report = Report(issues=set(scanner.issues))
     report_path = report.generate(file_type=report_type)
     click.secho("Finish writing report to {report_path}...".format(report_path=report_path))
 


### PR DESCRIPTION
1. Dedupes based on Issue's `__hash__` function. Checking issue name, file path, and line number
2. Removes the `rmtree` call for the build directory. This was not allowing  `--java` to run properly as it would have deleted the directory.
3. Minor fixes in random plugins that I have seen in the generated report