### PR TITLE
Rearchitect plugins for speed instead of user control

### DIFF
--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -12,7 +12,7 @@ from multiprocessing.pool import ThreadPool
 import requests
 
 from qark.decompiler.external_decompiler import DECOMPILERS
-from qark.utils import create_directories_to_path
+from qark.utils import create_directories_to_path, is_java_file
 
 log = logging.getLogger(__name__)
 
@@ -70,7 +70,7 @@ class Decompiler(object):
                                                                                                             ".apk"):
             raise ValueError("Invalid path, path must be to an APK, directory, or a Java file")
 
-        if os.path.isdir(path_to_source) or os.path.splitext(path_to_source.lower())[1] == ".java":
+        if os.path.isdir(path_to_source) or is_java_file(path_to_source):
             self.source_code = True
             self.manifest_path = None
             log.debug("Decompiler got directory to run on, assuming Java source code")

--- a/qark/plugins/broadcast/send_broadcast_receiver_permission.py
+++ b/qark/plugins/broadcast/send_broadcast_receiver_permission.py
@@ -67,7 +67,7 @@ class SendBroadcastReceiverPermission(BasePlugin):
     based on number of arguments.
     """
     def __init__(self):
-        BasePlugin.__init__(self, category="broadcast")
+        BasePlugin.__init__(self, category="broadcast", name="Send Broadcast Receiver Permission")
         self.severity = Severity.WARNING
         self.current_file = None
         self.manifest_xml = None
@@ -176,7 +176,7 @@ def has_local_broadcast_imported(import_tree):
     :return: True if import tree has broadcast import, else False
     :rtype: bool
     """
-    return any([import_declaration.path in LOCAL_BROADCAST_IMPORTS for import_declaration in import_tree])
+    return any(import_declaration.path in LOCAL_BROADCAST_IMPORTS for import_declaration in import_tree)
 
 
 plugin = SendBroadcastReceiverPermission()

--- a/qark/plugins/cert/cert_validation_methods_overriden.py
+++ b/qark/plugins/cert/cert_validation_methods_overriden.py
@@ -34,7 +34,7 @@ class CertValidation(BasePlugin):
     SSL connections.
     """
     def __init__(self):
-        BasePlugin.__init__(self, category="cert")
+        BasePlugin.__init__(self, category="cert", name="Certification Validation")
         self.severity = Severity.WARNING
 
     def run(self, filepath, java_ast=None, **kwargs):

--- a/qark/plugins/cert/hostname_verifier.py
+++ b/qark/plugins/cert/hostname_verifier.py
@@ -32,7 +32,7 @@ class HostnameVerifier(BasePlugin):
      2. `setHostnameVerifier` is called with a value of `.ALLOW_ALL_HOSTNAME_VERIFIERS`
     """
     def __init__(self):
-        BasePlugin.__init__(self, category="cert")
+        BasePlugin.__init__(self, category="cert", name="Hostname Verifier")
         self.severity = Severity.WARNING
 
     def run(self, filepath, java_ast=None, **kwargs):

--- a/qark/plugins/cert/hostname_verifier.py
+++ b/qark/plugins/cert/hostname_verifier.py
@@ -4,8 +4,7 @@ import javalang
 from javalang.tree import ClassCreator, MemberReference, MethodInvocation
 
 from qark.issue import Issue, Severity
-from qark.scanner.plugin import BasePlugin
-from qark.plugins.helpers import java_files_from_files
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -25,22 +24,19 @@ ALLOW_ALL_HOSTNAME_VERIFIER_DESC = ("This can allow for impromper x.509 certific
                                     "https://developer.android.com/training/articles/security-ssl.html")
 
 
-class HostnameVerifier(BasePlugin):
+class HostnameVerifier(JavaASTPlugin):
     """
     This plugin checks if:
      1. `AllowAllHostnameVerifier` is instantiated
      2. `setHostnameVerifier` is called with a value of `.ALLOW_ALL_HOSTNAME_VERIFIERS`
     """
     def __init__(self):
-        BasePlugin.__init__(self, category="cert", name="Hostname Verifier")
+        JavaASTPlugin.__init__(self, category="cert", name="Hostname Verifier")
         self.severity = Severity.WARNING
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        self._allow_all_hostname_verifier_created(java_ast, filepath)
-        self._set_hostname_verifier_allow_all(java_ast, filepath)
+    def run(self):
+        self._allow_all_hostname_verifier_created(self.java_ast, self.file_path)
+        self._set_hostname_verifier_allow_all(self.java_ast, self.file_path)
 
     def _allow_all_hostname_verifier_created(self, tree, current_file):
         """

--- a/qark/plugins/cert/hostname_verifier.py
+++ b/qark/plugins/cert/hostname_verifier.py
@@ -31,7 +31,7 @@ class HostnameVerifier(JavaASTPlugin):
      2. `setHostnameVerifier` is called with a value of `.ALLOW_ALL_HOSTNAME_VERIFIERS`
     """
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="cert", name="Hostname Verifier")
+        super(HostnameVerifier, self).__init__(category="cert", name="Hostname Verifier")
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/crypto/ecb_cipher_usage.py
+++ b/qark/plugins/crypto/ecb_cipher_usage.py
@@ -13,8 +13,8 @@ log = logging.getLogger(__name__)
 class ECBCipherCheck(JavaASTPlugin):
     def __init__(self):
 
-        JavaASTPlugin.__init__(self, category="crypto", name="ECB Cipher Usage",
-                               description="ECB mode is an insecure encryption technique and prone to data leakage")
+        super(ECBCipherCheck, self).__init__(category="crypto", name="ECB Cipher Usage",
+                                             description="ECB mode is an insecure encryption technique and prone to data leakage")
 
         self.severity = Severity.VULNERABILITY
 

--- a/qark/plugins/crypto/ecb_cipher_usage.py
+++ b/qark/plugins/crypto/ecb_cipher_usage.py
@@ -4,26 +4,22 @@ import logging
 import re
 import javalang
 
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
 
 log = logging.getLogger(__name__)
 
 
-class ECBCipherCheck(BasePlugin):
+class ECBCipherCheck(JavaASTPlugin):
     def __init__(self):
 
-        BasePlugin.__init__(self, category="crypto", name="ECB Cipher Usage",
-                            description="ECB mode is an insecure encryption technique and prone to data leakage")
+        JavaASTPlugin.__init__(self, category="crypto", name="ECB Cipher Usage",
+                               description="ECB mode is an insecure encryption technique and prone to data leakage")
 
         self.severity = Severity.VULNERABILITY
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        method_invocations = java_ast.filter(javalang.tree.MethodInvocation)
+    def run(self):
+        method_invocations = self.java_ast.filter(javalang.tree.MethodInvocation)
         for _, method_invocation_node in method_invocations:
             try:
                 method_name = method_invocation_node.member
@@ -33,7 +29,7 @@ class ECBCipherCheck(BasePlugin):
                                                                                         encryption_type):
                     description = "getInstance should not be called with ECB as the cipher mode, as it is insecure."
                     self.issues.append(
-                        Issue(self.category, self.name, self.severity, description, file_object=filepath))
+                        Issue(self.category, self.name, self.severity, description, file_object=self.file_path))
             except Exception:
                 continue
 

--- a/qark/plugins/crypto/ecb_cipher_usage.py
+++ b/qark/plugins/crypto/ecb_cipher_usage.py
@@ -15,7 +15,7 @@ class ECBCipherCheck(BasePlugin):
     def __init__(self):
 
         BasePlugin.__init__(self, category="crypto", name="ECB Cipher Usage",
-                            description=("ECB mode is an insecure encryption technique and prone to data leakage"))
+                            description="ECB mode is an insecure encryption technique and prone to data leakage")
 
         self.severity = Severity.VULNERABILITY
 

--- a/qark/plugins/crypto/packaged_private_keys.py
+++ b/qark/plugins/crypto/packaged_private_keys.py
@@ -11,7 +11,8 @@ class PackagedPrivateKeys(FileContentsPlugin):
     PRIVATE_KEY_REGEXES = (r'PRIVATE\sKEY',)
 
     def __init__(self):
-        FileContentsPlugin.__init__(self, category="crypto", name="Encryption keys are packaged with the application")
+        super(PackagedPrivateKeys, self).__init__(category="crypto",
+                                                  name="Encryption keys are packaged with the application")
 
         self.severity = Severity.VULNERABILITY
 

--- a/qark/plugins/crypto/packaged_private_keys.py
+++ b/qark/plugins/crypto/packaged_private_keys.py
@@ -16,14 +16,16 @@ class PackagedPrivateKeys(BasePlugin):
 
         self.severity = Severity.VULNERABILITY
 
-    def run(self, files, apk_constants=None):
-        for file_path in files:
-            for regex in PackagedPrivateKeys.PRIVATE_KEY_REGEXES:
-                if run_regex(file_path, regex):
-                    log.debug("It appears there is a private key embedded in your application: %s", file_path)
-                    description = "It appears there is a private key embedded in your application in the following file:"
-                    self.issues.append(
-                        Issue(self.category, self.name, self.severity, description, file_object=file_path))
+    def run(self, filepath, file_contents=None, **kwargs):
+        if not file_contents:
+            return
+
+        for regex in PackagedPrivateKeys.PRIVATE_KEY_REGEXES:
+            if run_regex(filepath, regex):
+                log.debug("It appears there is a private key embedded in your application: %s", filepath)
+                description = "It appears there is a private key embedded in your application in the following file:"
+                self.issues.append(
+                    Issue(self.category, self.name, self.severity, description, file_object=filepath))
 
 
 plugin = PackagedPrivateKeys()

--- a/qark/plugins/crypto/packaged_private_keys.py
+++ b/qark/plugins/crypto/packaged_private_keys.py
@@ -1,31 +1,27 @@
 import logging
 
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import FileContentsPlugin
 from qark.issue import Severity, Issue
 from qark.plugins.helpers import run_regex
 
 log = logging.getLogger(__name__)
 
 
-class PackagedPrivateKeys(BasePlugin):
-
+class PackagedPrivateKeys(FileContentsPlugin):
     PRIVATE_KEY_REGEXES = (r'PRIVATE\sKEY',)
 
     def __init__(self):
-        BasePlugin.__init__(self, category="crypto", name="Encryption keys are packaged with the application")
+        FileContentsPlugin.__init__(self, category="crypto", name="Encryption keys are packaged with the application")
 
         self.severity = Severity.VULNERABILITY
 
-    def run(self, filepath, file_contents=None, **kwargs):
-        if not file_contents:
-            return
-
+    def run(self):
         for regex in PackagedPrivateKeys.PRIVATE_KEY_REGEXES:
-            if run_regex(filepath, regex):
-                log.debug("It appears there is a private key embedded in your application: %s", filepath)
+            if run_regex(self.file_path, regex):
+                log.debug("It appears there is a private key embedded in your application: %s", self.file_path)
                 description = "It appears there is a private key embedded in your application in the following file:"
                 self.issues.append(
-                    Issue(self.category, self.name, self.severity, description, file_object=filepath))
+                    Issue(self.category, self.name, self.severity, description, file_object=self.file_path))
 
 
 plugin = PackagedPrivateKeys()

--- a/qark/plugins/crypto/setting_secure_random_seed.py
+++ b/qark/plugins/crypto/setting_secure_random_seed.py
@@ -24,7 +24,7 @@ class SeedWithSecureRandom(BasePlugin):
 
     def _imports_secure_seed(self, tree):
         """Checks if a tree imports java.security.SecureRandom, and returns True if the import exists"""
-        return any([imp.path == "java.security.SecureRandom" for imp in tree.imports])
+        return any(imp.path == "java.security.SecureRandom" for imp in tree.imports)
 
     def run(self, filepath, java_ast=None, **kwargs):
         if not java_ast:

--- a/qark/plugins/crypto/setting_secure_random_seed.py
+++ b/qark/plugins/crypto/setting_secure_random_seed.py
@@ -3,22 +3,21 @@ import logging
 
 import javalang
 
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
 
 log = logging.getLogger(__name__)
 
 
-class SeedWithSecureRandom(BasePlugin):
+class SeedWithSecureRandom(JavaASTPlugin):
 
     INSECURE_FUNCTIONS = ("setSeed", "generateSeed")
 
     def __init__(self):
 
-        BasePlugin.__init__(self, category="crypto", name="Random number generator is seeded with SecureSeed",
-                            description=("Specifying a fixed seed will cause a predictable sequence of numbers. "
-                                         "This may be useful for testing, but not for secure use"))
+        JavaASTPlugin.__init__(self, category="crypto", name="Random number generator is seeded with SecureSeed",
+                               description=("Specifying a fixed seed will cause a predictable sequence of numbers. "
+                                            "This may be useful for testing, but not for secure use"))
 
         self.severity = Severity.WARNING
 
@@ -26,18 +25,15 @@ class SeedWithSecureRandom(BasePlugin):
         """Checks if a tree imports java.security.SecureRandom, and returns True if the import exists"""
         return any(imp.path == "java.security.SecureRandom" for imp in tree.imports)
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
+    def run(self):
+        if not self._imports_secure_seed(self.java_ast):  # doesn't import the insecure function
             return
 
-        if not self._imports_secure_seed(java_ast):  # doesn't import the insecure function
-            return
-
-        method_invocations = java_ast.filter(javalang.tree.MethodInvocation)
+        method_invocations = self.java_ast.filter(javalang.tree.MethodInvocation)
         for _, method_invocation_node in method_invocations:
             if method_invocation_node.member in SeedWithSecureRandom.INSECURE_FUNCTIONS:
                 self.issues.append(Issue(self.category, self.name, self.severity, self.description,
-                                         file_object=filepath))
+                                         file_object=self.file_path))
 
 
 plugin = SeedWithSecureRandom()

--- a/qark/plugins/crypto/setting_secure_random_seed.py
+++ b/qark/plugins/crypto/setting_secure_random_seed.py
@@ -15,9 +15,11 @@ class SeedWithSecureRandom(JavaASTPlugin):
 
     def __init__(self):
 
-        JavaASTPlugin.__init__(self, category="crypto", name="Random number generator is seeded with SecureSeed",
-                               description=("Specifying a fixed seed will cause a predictable sequence of numbers. "
-                                            "This may be useful for testing, but not for secure use"))
+        super(SeedWithSecureRandom, self).__init__(category="crypto",
+                                                   name="Random number generator is seeded with SecureSeed",
+                                                   description=(
+                                                       "Specifying a fixed seed will cause a predictable sequence of numbers. "
+                                                       "This may be useful for testing, but not for secure use"))
 
         self.severity = Severity.WARNING
 

--- a/qark/plugins/file/android_logging.py
+++ b/qark/plugins/file/android_logging.py
@@ -36,32 +36,16 @@ class AndroidLogging(BasePlugin):
                             description=ANDROID_LOGGING_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file)
-
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        for _, method_invocation in tree.filter(MethodInvocation):
+        for _, method_invocation in java_ast.filter(MethodInvocation):
             if method_invocation.qualifier == "Log" and method_invocation.member in ANDROID_LOGGING_METHODS:
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,
                     description=self.description,
-                    file_object=java_file,
+                    file_object=filepath,
                     line_number=method_invocation.position)
                 )
 

--- a/qark/plugins/file/android_logging.py
+++ b/qark/plugins/file/android_logging.py
@@ -17,7 +17,7 @@ from javalang.tree import MethodInvocation
 
 from qark.issue import Severity, Issue
 from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -30,22 +30,19 @@ ANDROID_LOGGING_DESCRIPTION = (
 ANDROID_LOGGING_METHODS = ("v", "d", "i", "w", "e")
 
 
-class AndroidLogging(BasePlugin):
+class AndroidLogging(JavaASTPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="Logging found",
-                            description=ANDROID_LOGGING_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="file", name="Logging found",
+                               description=ANDROID_LOGGING_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        for _, method_invocation in java_ast.filter(MethodInvocation):
+    def run(self):
+        for _, method_invocation in self.java_ast.filter(MethodInvocation):
             if method_invocation.qualifier == "Log" and method_invocation.member in ANDROID_LOGGING_METHODS:
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,
                     description=self.description,
-                    file_object=filepath,
+                    file_object=self.file_path,
                     line_number=method_invocation.position)
                 )
 

--- a/qark/plugins/file/android_logging.py
+++ b/qark/plugins/file/android_logging.py
@@ -32,8 +32,8 @@ ANDROID_LOGGING_METHODS = ("v", "d", "i", "w", "e")
 
 class AndroidLogging(JavaASTPlugin):
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="file", name="Logging found",
-                               description=ANDROID_LOGGING_DESCRIPTION)
+        super(AndroidLogging, self).__init__(category="file", name="Logging found",
+                                             description=ANDROID_LOGGING_DESCRIPTION)
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/file/api_keys.py
+++ b/qark/plugins/file/api_keys.py
@@ -5,8 +5,7 @@ import logging
 import re
 
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import FileContentsPlugin
 
 log = logging.getLogger(__name__)
 
@@ -16,23 +15,20 @@ SPECIAL_CHARACTER_REGEX = re.compile(r'(?=.+[!$%^&*()_+|~=`{}\[\]:<>?,./])')
 API_KEY_DESCRIPTION = "Please confirm and investigate the API key to determine its severity."
 
 
-class JavaAPIKeys(BasePlugin):
+class JavaAPIKeys(FileContentsPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="Potential API Key found",
-                            description=API_KEY_DESCRIPTION)
+        FileContentsPlugin.__init__(self, category="file", name="Potential API Key found",
+                               description=API_KEY_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, filepath, file_contents=None, **kwargs):
-        if not file_contents:
-            return
-
-        for line_number, line in enumerate(file_contents.split("\n")):
+    def run(self):
+        for line_number, line in enumerate(self.file_contents.split("\n")):
             for word in line.split():
                 if re.search(API_KEY_REGEX, word) and not re.search(SPECIAL_CHARACTER_REGEX, word):
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=filepath,
+                        file_object=self.file_path,
                         line_number=(line_number, 0))
                     )
 

--- a/qark/plugins/file/api_keys.py
+++ b/qark/plugins/file/api_keys.py
@@ -17,8 +17,8 @@ API_KEY_DESCRIPTION = "Please confirm and investigate the API key to determine i
 
 class JavaAPIKeys(FileContentsPlugin):
     def __init__(self):
-        FileContentsPlugin.__init__(self, category="file", name="Potential API Key found",
-                               description=API_KEY_DESCRIPTION)
+        super(JavaAPIKeys, self).__init__(category="file", name="Potential API Key found",
+                                          description=API_KEY_DESCRIPTION)
         self.severity = Severity.INFO
 
     def run(self):

--- a/qark/plugins/file/api_keys.py
+++ b/qark/plugins/file/api_keys.py
@@ -22,22 +22,19 @@ class JavaAPIKeys(BasePlugin):
                             description=API_KEY_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            self._process(java_file)
+    def run(self, filepath, file_contents=None, **kwargs):
+        if not file_contents:
+            return
 
-    def _process(self, java_file_path):
-        with open(java_file_path, "r") as java_file:
-            for line_number, line in enumerate(java_file, 1):
-                for word in line.split():
-                    if re.search(API_KEY_REGEX, word) and not re.search(SPECIAL_CHARACTER_REGEX, word):
-                        self.issues.append(Issue(
-                            category=self.category, severity=self.severity, name=self.name,
-                            description=self.description,
-                            file_object=java_file_path,
-                            line_number=(line_number, 0))
-                        )
+        for line_number, line in enumerate(file_contents.split("\n")):
+            for word in line.split():
+                if re.search(API_KEY_REGEX, word) and not re.search(SPECIAL_CHARACTER_REGEX, word):
+                    self.issues.append(Issue(
+                        category=self.category, severity=self.severity, name=self.name,
+                        description=self.description,
+                        file_object=filepath,
+                        line_number=(line_number, 0))
+                    )
 
 
 plugin = JavaAPIKeys()

--- a/qark/plugins/file/external_storage.py
+++ b/qark/plugins/file/external_storage.py
@@ -34,8 +34,8 @@ EXTERNAL_STORAGE_PUBLIC_DIR_METHOD = 'getExternalStoragePublicDirectory'
 
 class ExternalStorage(JavaASTPlugin):
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="file", name="External storage used",
-                               description=EXTERNAL_STORAGE_DESCRIPTION)
+        super(ExternalStorage, self).__init__(category="file", name="External storage used",
+                                              description=EXTERNAL_STORAGE_DESCRIPTION)
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/file/external_storage.py
+++ b/qark/plugins/file/external_storage.py
@@ -15,7 +15,7 @@ from javalang.tree import MethodInvocation
 
 from qark.issue import Severity, Issue
 from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -32,17 +32,14 @@ EXTERNAL_MEDIA_DIR_METHOD = 'getExternalMediaDirs'
 EXTERNAL_STORAGE_PUBLIC_DIR_METHOD = 'getExternalStoragePublicDirectory'
 
 
-class ExternalStorage(BasePlugin):
+class ExternalStorage(JavaASTPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="External storage used",
-                            description=EXTERNAL_STORAGE_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="file", name="External storage used",
+                               description=EXTERNAL_STORAGE_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        for _, method_invocation in java_ast.filter(MethodInvocation):
+    def run(self):
+        for _, method_invocation in self.java_ast.filter(MethodInvocation):
             storage_location = None
             if (method_invocation.member == EXTERNAL_FILES_DIR_METHOD
                     or method_invocation.member == EXTERNAL_FILES_DIRS_METHOD):
@@ -58,7 +55,7 @@ class ExternalStorage(BasePlugin):
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,
                     description=self.description,
-                    file_object=filepath,
+                    file_object=self.file_path,
                     line_number=method_invocation.position)
                 )
 

--- a/qark/plugins/file/file_permissions.py
+++ b/qark/plugins/file/file_permissions.py
@@ -19,7 +19,7 @@ class FilePermissions(FileContentsPlugin):
     This module runs a regex search on every Java file looking for `WORLD_READABLE` and `WORLD_WRITEABLE` modes.
     """
     def __init__(self):
-        FileContentsPlugin.__init__(self, category="file", name="File Permissions")
+        super(FilePermissions, self).__init__(category="file", name="File Permissions")
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/file/file_permissions.py
+++ b/qark/plugins/file/file_permissions.py
@@ -22,15 +22,16 @@ class FilePermissions(BasePlugin):
         BasePlugin.__init__(self, category="file")
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            if run_regex(java_file, WORLD_READABLE):
-                self.issues.append(Issue(category=self.category, name="World readable file", severity=self.severity,
-                                         description=WORLD_READABLE_DESCRIPTION, file_object=java_file))
-            if run_regex(java_file, WORLD_WRITEABLE):
-                self.issues.append(Issue(category=self.category, name="World writeable file", severity=self.severity,
-                                         description=WORLD_WRITEABLE_DESCRIPTION, file_object=java_file))
+    def run(self, filepath, file_contents=None, **kwargs):
+        if not file_contents:
+            return
+
+        if run_regex(filepath, WORLD_READABLE):
+            self.issues.append(Issue(category=self.category, name="World readable file", severity=self.severity,
+                                     description=WORLD_READABLE_DESCRIPTION, file_object=filepath))
+        if run_regex(filepath, WORLD_WRITEABLE):
+            self.issues.append(Issue(category=self.category, name="World writeable file", severity=self.severity,
+                                     description=WORLD_WRITEABLE_DESCRIPTION, file_object=filepath))
 
 
 plugin = FilePermissions()

--- a/qark/plugins/file/file_permissions.py
+++ b/qark/plugins/file/file_permissions.py
@@ -1,5 +1,5 @@
-from qark.plugins.helpers import java_files_from_files, run_regex
-from qark.scanner.plugin import BasePlugin
+from qark.plugins.helpers import run_regex
+from qark.scanner.plugin import FileContentsPlugin
 from qark.issue import Severity, Issue
 
 import logging
@@ -14,24 +14,21 @@ WORLD_READABLE_DESCRIPTION = "World readable file found. Any application or file
 WORLD_WRITEABLE_DESCRIPTION = "World writeable file found. Any application or file browser can write to this file"
 
 
-class FilePermissions(BasePlugin):
+class FilePermissions(FileContentsPlugin):
     """
     This module runs a regex search on every Java file looking for `WORLD_READABLE` and `WORLD_WRITEABLE` modes.
     """
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="File Permissions")
+        FileContentsPlugin.__init__(self, category="file", name="File Permissions")
         self.severity = Severity.WARNING
 
-    def run(self, filepath, file_contents=None, **kwargs):
-        if not file_contents:
-            return
-
-        if run_regex(filepath, WORLD_READABLE):
+    def run(self):
+        if run_regex(self.file_path, WORLD_READABLE):
             self.issues.append(Issue(category=self.category, name="World readable file", severity=self.severity,
-                                     description=WORLD_READABLE_DESCRIPTION, file_object=filepath))
-        if run_regex(filepath, WORLD_WRITEABLE):
+                                     description=WORLD_READABLE_DESCRIPTION, file_object=self.file_path))
+        if run_regex(self.file_path, WORLD_WRITEABLE):
             self.issues.append(Issue(category=self.category, name="World writeable file", severity=self.severity,
-                                     description=WORLD_WRITEABLE_DESCRIPTION, file_object=filepath))
+                                     description=WORLD_WRITEABLE_DESCRIPTION, file_object=self.file_path))
 
 
 plugin = FilePermissions()

--- a/qark/plugins/file/file_permissions.py
+++ b/qark/plugins/file/file_permissions.py
@@ -19,7 +19,7 @@ class FilePermissions(BasePlugin):
     This module runs a regex search on every Java file looking for `WORLD_READABLE` and `WORLD_WRITEABLE` modes.
     """
     def __init__(self):
-        BasePlugin.__init__(self, category="file")
+        BasePlugin.__init__(self, category="file", name="File Permissions")
         self.severity = Severity.WARNING
 
     def run(self, filepath, file_contents=None, **kwargs):

--- a/qark/plugins/file/http_url_hardcoded.py
+++ b/qark/plugins/file/http_url_hardcoded.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import os
 
 import javalang
 
@@ -23,18 +24,8 @@ class HardcodedHTTP(BasePlugin):
                             description=HARDCODED_HTTP_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file)
-
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, file_contents=None, **kwargs):
+        if not file_contents or not os.path.splitext(filepath.lower())[1] == ".java":
             return
 
         for line_number, line in enumerate(file_contents.split('\n')):
@@ -43,7 +34,7 @@ class HardcodedHTTP(BasePlugin):
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,
                     description=self.description.format(http_url=http_url_match.group(0)),
-                    file_object=java_file,
+                    file_object=filepath,
                     line_number=(line_number, 0))
                 )
 

--- a/qark/plugins/file/http_url_hardcoded.py
+++ b/qark/plugins/file/http_url_hardcoded.py
@@ -1,12 +1,9 @@
 import logging
 import re
-import os
-
-import javalang
 
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.utils import is_java_file
+from qark.scanner.plugin import FileContentsPlugin
 
 log = logging.getLogger(__name__)
 
@@ -18,23 +15,23 @@ HARDCODED_HTTP_DESCRIPTION = (
 HTTP_URL_REGEX = re.compile(r'http://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*(),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+')
 
 
-class HardcodedHTTP(BasePlugin):
+class HardcodedHTTP(FileContentsPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="Hardcoded HTTP url found",
-                            description=HARDCODED_HTTP_DESCRIPTION)
+        super(HardcodedHTTP, self).__init__(category="file", name="Hardcoded HTTP url found",
+                                            description=HARDCODED_HTTP_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, filepath, file_contents=None, **kwargs):
-        if not file_contents or not os.path.splitext(filepath.lower())[1] == ".java":
+    def run(self):
+        if not is_java_file(self.file_path):
             return
 
-        for line_number, line in enumerate(file_contents.split('\n')):
+        for line_number, line in enumerate(self.file_contents.split('\n')):
             http_url_match = re.search(HTTP_URL_REGEX, line)
             if http_url_match:
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,
                     description=self.description.format(http_url=http_url_match.group(0)),
-                    file_object=filepath,
+                    file_object=self.file_path,
                     line_number=(line_number, 0))
                 )
 

--- a/qark/plugins/file/insecure_functions.py
+++ b/qark/plugins/file/insecure_functions.py
@@ -21,8 +21,8 @@ INSECURE_FUNCTIONS_NAMES = ("call",)
 
 class InsecureFunctions(JavaASTPlugin):
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="file", name="Insecure functions found",
-                               description=INSECURE_FUNCTIONS_DESCRIPTION)
+        super(InsecureFunctions, self).__init__(category="file", name="Insecure functions found",
+                                                description=INSECURE_FUNCTIONS_DESCRIPTION)
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/file/insecure_functions.py
+++ b/qark/plugins/file/insecure_functions.py
@@ -4,8 +4,7 @@ import javalang
 from javalang.tree import ClassDeclaration, MethodDeclaration
 
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -20,24 +19,21 @@ INSECURE_FUNCTIONS_DESCRIPTION = (
 INSECURE_FUNCTIONS_NAMES = ("call",)
 
 
-class InsecureFunctions(BasePlugin):
+class InsecureFunctions(JavaASTPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="Insecure functions found",
-                            description=INSECURE_FUNCTIONS_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="file", name="Insecure functions found",
+                               description=INSECURE_FUNCTIONS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        for _, class_declaration in java_ast.filter(ClassDeclaration):
+    def run(self):
+        for _, class_declaration in self.java_ast.filter(ClassDeclaration):
             for _, method_declaration_in_class in class_declaration.filter(MethodDeclaration):
 
                 if method_declaration_in_class.name in INSECURE_FUNCTIONS_NAMES:
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=filepath,
+                        file_object=self.file_path,
                         line_number=method_declaration_in_class.position)
                     )
 

--- a/qark/plugins/file/insecure_functions.py
+++ b/qark/plugins/file/insecure_functions.py
@@ -26,33 +26,18 @@ class InsecureFunctions(BasePlugin):
                             description=INSECURE_FUNCTIONS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file)
-
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        for _, class_declaration in tree.filter(ClassDeclaration):
+        for _, class_declaration in java_ast.filter(ClassDeclaration):
             for _, method_declaration_in_class in class_declaration.filter(MethodDeclaration):
+
                 if method_declaration_in_class.name in INSECURE_FUNCTIONS_NAMES:
                     self.issues.append(Issue(
                         category=self.category, severity=self.severity, name=self.name,
                         description=self.description,
-                        file_object=java_file,
+                        file_object=filepath,
                         line_number=method_declaration_in_class.position)
                     )
 

--- a/qark/plugins/file/phone_identifier.py
+++ b/qark/plugins/file/phone_identifier.py
@@ -18,8 +18,8 @@ TELEPHONY_INLINE_REGEX = re.compile(r'\({2,}(android.telephony.)?TelephonyManage
 
 class PhoneIdentifier(FileContentsPlugin):
     def __init__(self):
-        FileContentsPlugin.__init__(self, category="file", name="Phone number or IMEI detected",
-                                    description=PHONE_IDENTIFIER_DESCRIPTION)
+        super(PhoneIdentifier, self).__init__(category="file", name="Phone number or IMEI detected",
+                                              description=PHONE_IDENTIFIER_DESCRIPTION)
         self.severity = Severity.INFO
 
     def run(self):

--- a/qark/plugins/file/phone_identifier.py
+++ b/qark/plugins/file/phone_identifier.py
@@ -23,23 +23,13 @@ class PhoneIdentifier(BasePlugin):
                             description=PHONE_IDENTIFIER_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file)
-
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, file_contents=None, **kwargs):
+        if not file_contents:
             return
 
         if re.search(TELEPHONY_MANAGER_REGEX, file_contents):
             if re.search(TELEPHONY_INLINE_REGEX, file_contents):
-                self._add_issue(java_path=java_file)
+                self._add_issue(java_path=filepath)
 
             else:
 
@@ -49,7 +39,7 @@ class PhoneIdentifier(BasePlugin):
 
                         if re.search(r'{var_name}\.(getLine1Number|getDeviceId)\(.*?\)'.format(var_name=variable_name),
                                      file_contents):
-                            self._add_issue(java_path=java_file)
+                            self._add_issue(java_path=filepath)
 
     def _add_issue(self, java_path):
         self.issues.append(Issue(

--- a/qark/plugins/file/phone_identifier.py
+++ b/qark/plugins/file/phone_identifier.py
@@ -2,8 +2,7 @@ import logging
 import re
 
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import FileContentsPlugin
 
 log = logging.getLogger(__name__)
 
@@ -17,29 +16,26 @@ TELEPHONY_INLINE_REGEX = re.compile(r'\({2,}(android.telephony.)?TelephonyManage
                                     r'[\'\"]\){2,}\.(getLine1Number|getDeviceId)')
 
 
-class PhoneIdentifier(BasePlugin):
+class PhoneIdentifier(FileContentsPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="file", name="Phone number or IMEI detected",
-                            description=PHONE_IDENTIFIER_DESCRIPTION)
+        FileContentsPlugin.__init__(self, category="file", name="Phone number or IMEI detected",
+                                    description=PHONE_IDENTIFIER_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, filepath, file_contents=None, **kwargs):
-        if not file_contents:
-            return
-
-        if re.search(TELEPHONY_MANAGER_REGEX, file_contents):
-            if re.search(TELEPHONY_INLINE_REGEX, file_contents):
-                self._add_issue(java_path=filepath)
+    def run(self):
+        if re.search(TELEPHONY_MANAGER_REGEX, self.file_contents):
+            if re.search(TELEPHONY_INLINE_REGEX, self.file_contents):
+                self._add_issue(java_path=self.file_path)
 
             else:
 
-                for match in re.finditer(TELEPHONY_MANAGER_VARIABLE_NAMES_REGEX, file_contents):
+                for match in re.finditer(TELEPHONY_MANAGER_VARIABLE_NAMES_REGEX, self.file_contents):
 
                     for variable_name in match.group(2):
 
                         if re.search(r'{var_name}\.(getLine1Number|getDeviceId)\(.*?\)'.format(var_name=variable_name),
-                                     file_contents):
-                            self._add_issue(java_path=filepath)
+                                     self.file_contents):
+                            self._add_issue(java_path=self.file_path)
 
     def _add_issue(self, java_path):
         self.issues.append(Issue(

--- a/qark/plugins/generic/check_permissions.py
+++ b/qark/plugins/generic/check_permissions.py
@@ -21,9 +21,9 @@ ENFORCE_PERMISSION_REGEX = re.compile(
 
 class CheckPermissions(JavaASTPlugin):
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="manifest",
-                               name="Potientially vulnerable check permission function called",
-                               description=CHECK_PERMISSIONS_DESCRIPTION)
+        super(CheckPermissions, self).__init__(category="manifest",
+                                               name="Potientially vulnerable check permission function called",
+                                               description=CHECK_PERMISSIONS_DESCRIPTION)
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/generic/check_permissions.py
+++ b/qark/plugins/generic/check_permissions.py
@@ -27,27 +27,11 @@ class CheckPermissions(BasePlugin):
                             description=CHECK_PERMISSIONS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file)
-
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, java_file, file_contents=None, java_ast=None, **kwargs):
+        if not file_contents or not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        if any(["Context" in imp.path for imp in tree.imports]):
+        if any(["Context" in imp.path for imp in java_ast.imports]):
             if re.search(CHECK_PERMISSION_REGEX, file_contents):
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,

--- a/qark/plugins/generic/check_permissions.py
+++ b/qark/plugins/generic/check_permissions.py
@@ -31,7 +31,7 @@ class CheckPermissions(BasePlugin):
         if not file_contents or not java_ast:
             return
 
-        if any(["Context" in imp.path for imp in java_ast.imports]):
+        if any("Context" in imp.path for imp in java_ast.imports):
             if re.search(CHECK_PERMISSION_REGEX, file_contents):
                 self.issues.append(Issue(
                     category=self.category, severity=self.severity, name=self.name,

--- a/qark/plugins/generic/task_affinity.py
+++ b/qark/plugins/generic/task_affinity.py
@@ -1,11 +1,8 @@
 import logging
 import re
 
-import javalang
-
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -18,22 +15,19 @@ NEW_TASK_REGEX = re.compile(r'FLAG_ACTIVITY_NEW_TASK')
 MULTIPLE_TASK_REGEX = re.compile(r'FLAG_ACTIVITY_MULTIPLE_TASK')
 
 
-class TaskAffinity(BasePlugin):
+class TaskAffinity(JavaASTPlugin):
     def __init__(self):
-        BasePlugin.__init__(self, category="generic", name="Potential task hijacking",
-                            description=TASK_AFFINITY_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="generic", name="Potential task hijacking",
+                               description=TASK_AFFINITY_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, filepath, file_contents=None, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        if any("Intent" in import_decl.path for import_decl in java_ast.imports):
+    def run(self):
+        if any("Intent" in import_decl.path for import_decl in self.java_ast.imports):
             description = None
 
-            if re.search(NEW_TASK_REGEX, file_contents):
+            if re.search(NEW_TASK_REGEX, self.file_contents):
                 description = TASK_AFFINITY_DESCRIPTION.format("NEW")
-            elif re.search(MULTIPLE_TASK_REGEX, file_contents):
+            elif re.search(MULTIPLE_TASK_REGEX, self.file_contents):
                 description = TASK_AFFINITY_DESCRIPTION.format("MULTIPLE")
 
             if description:
@@ -41,7 +35,7 @@ class TaskAffinity(BasePlugin):
                                          severity=self.severity,
                                          name=self.name,
                                          description=description,
-                                         file_object=filepath))
+                                         file_object=self.file_path))
 
 
 plugin = TaskAffinity()

--- a/qark/plugins/generic/task_affinity.py
+++ b/qark/plugins/generic/task_affinity.py
@@ -17,8 +17,8 @@ MULTIPLE_TASK_REGEX = re.compile(r'FLAG_ACTIVITY_MULTIPLE_TASK')
 
 class TaskAffinity(JavaASTPlugin):
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="generic", name="Potential task hijacking",
-                               description=TASK_AFFINITY_DESCRIPTION)
+        super(TaskAffinity, self).__init__(category="generic", name="Potential task hijacking",
+                                           description=TASK_AFFINITY_DESCRIPTION)
         self.severity = Severity.INFO
 
     def run(self):

--- a/qark/plugins/generic/task_affinity.py
+++ b/qark/plugins/generic/task_affinity.py
@@ -28,7 +28,7 @@ class TaskAffinity(BasePlugin):
         if not java_ast:
             return
 
-        if any(["Intent" in import_decl.path for import_decl in java_ast.imports]):
+        if any("Intent" in import_decl.path for import_decl in java_ast.imports):
             description = None
 
             if re.search(NEW_TASK_REGEX, file_contents):

--- a/qark/plugins/generic/task_affinity.py
+++ b/qark/plugins/generic/task_affinity.py
@@ -24,27 +24,11 @@ class TaskAffinity(BasePlugin):
                             description=TASK_AFFINITY_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file)
-
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("Error parsing file %s, continuing", java_file)
+    def run(self, filepath, file_contents=None, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        if any(["Intent" in import_decl.path for import_decl in tree.imports]):
+        if any(["Intent" in import_decl.path for import_decl in java_ast.imports]):
             description = None
 
             if re.search(NEW_TASK_REGEX, file_contents):
@@ -57,7 +41,7 @@ class TaskAffinity(BasePlugin):
                                          severity=self.severity,
                                          name=self.name,
                                          description=description,
-                                         file_object=java_file))
+                                         file_object=filepath))
 
 
 plugin = TaskAffinity()

--- a/qark/plugins/helpers.py
+++ b/qark/plugins/helpers.py
@@ -5,6 +5,7 @@ import shutil
 
 from javalang.tree import MethodInvocation
 from qark.plugins.manifest_helpers import get_min_sdk
+from qark.utils import is_java_file
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +49,7 @@ def java_files_from_files(files):
     :param list files:
     :return: generator of file paths
     """
-    return (file_path for file_path in files if os.path.splitext(file_path.lower())[1] == '.java')
+    return (file_path for file_path in files if is_java_file(file_path))
 
 
 def remove_dict_entry_by_value(dictionary, value):

--- a/qark/plugins/intent/implicit_intent_to_pending_intent.py
+++ b/qark/plugins/intent/implicit_intent_to_pending_intent.py
@@ -37,7 +37,7 @@ class ImplicitIntentToPendingIntent(BasePlugin):
         self.severity = Severity.VULNERABILITY
         self.current_file = None
 
-    def run(self, filepath, apk_constants=None, file_contents=None, java_ast=None, **kwargs):
+    def run(self, filepath, file_contents=None, java_ast=None, **kwargs):
         if not file_contents or not java_ast:
             return
 
@@ -45,7 +45,7 @@ class ImplicitIntentToPendingIntent(BasePlugin):
         if re.search("new Intent", file_contents) is None or re.search(PENDING_INTENT_REGEX, file_contents) is None:
             return
 
-        if not any(["PendingIntent" in imported_declaration.path for imported_declaration in java_ast.imports]):
+        if not any("PendingIntent" in imported_declaration.path for imported_declaration in java_ast.imports):
             # if PendingIntent is never imported the file is not vulnerable
             return
 

--- a/qark/plugins/intent/implicit_intent_to_pending_intent.py
+++ b/qark/plugins/intent/implicit_intent_to_pending_intent.py
@@ -24,14 +24,15 @@ class ImplicitIntentToPendingIntent(JavaASTPlugin):
     If there is, a Vulnerability is created.
     """
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="intent", name="Empty pending intent found",
-                               description=("For security reasons, the Intent you supply here should almost always"
-                                            " be an explicit intent that is specify an explicit component to be delivered"
-                                            " to through Intent.setClass. A malicious application could potentially"
-                                            " intercept, redirect and/or modify this Intent. Pending Intents retain the"
-                                            " UID of your application and all related permissions, allowing another"
-                                            " application to act as yours. Reference: "
-                                            "https://developer.android.com/reference/android/app/PendingIntent.html"))
+        super(ImplicitIntentToPendingIntent, self).__init__(category="intent", name="Empty pending intent found",
+                                                            description=(
+                                                                "For security reasons, the Intent you supply here should almost always"
+                                                                " be an explicit intent that is specify an explicit component to be delivered"
+                                                                " to through Intent.setClass. A malicious application could potentially"
+                                                                " intercept, redirect and/or modify this Intent. Pending Intents retain the"
+                                                                " UID of your application and all related permissions, allowing another"
+                                                                " application to act as yours. Reference: "
+                                                                "https://developer.android.com/reference/android/app/PendingIntent.html"))
         self.severity = Severity.VULNERABILITY
         self.current_file = None
 

--- a/qark/plugins/manifest/allow_backup.py
+++ b/qark/plugins/manifest/allow_backup.py
@@ -7,22 +7,17 @@ log = logging.getLogger(__name__)
 
 
 class ManifestBackupAllowed(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(dict(category="manifest", name="Backup is allowed in manifest",
-                           description=(
-                               "Backups enabled: Potential for data theft via local attacks via adb "
-                               "backup, if the device has USB debugging enabled (not common). "
-                               "More info: "
-                               "http://developer.android.com/reference/android/R.attr.html#allowBackup")))
-
-        super(ManifestBackupAllowed, self).__init__(**kwargs)
+    def __init__(self):
+        super(ManifestBackupAllowed, self).__init__(category="manifest", name="Backup is allowed in manifest",
+                                                    description=(
+                                                        "Backups enabled: Potential for data theft via local attacks via adb "
+                                                        "backup, if the device has USB debugging enabled (not common). "
+                                                        "More info: "
+                                                        "http://developer.android.com/reference/android/R.attr.html#allowBackup"))
 
         self.severity = Severity.WARNING
 
-    def run(self, **kwargs):
-        if not self.manifest_xml:
-            return
-
+    def run(self):
         application_sections = self.manifest_xml.getElementsByTagName("application")
 
         for application in application_sections:

--- a/qark/plugins/manifest/allow_backup.py
+++ b/qark/plugins/manifest/allow_backup.py
@@ -19,7 +19,7 @@ class ManifestBackupAllowed(ManifestPlugin):
 
         self.severity = Severity.WARNING
 
-    def run(self, filepath, apk_constants=None, **kwargs):
+    def run(self, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/allow_backup.py
+++ b/qark/plugins/manifest/allow_backup.py
@@ -19,7 +19,7 @@ class ManifestBackupAllowed(ManifestPlugin):
 
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
+    def run(self, filepath, apk_constants=None, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/android_path.py
+++ b/qark/plugins/manifest/android_path.py
@@ -10,15 +10,13 @@ PATH_USAGE_DESCRIPTION = ("android:path means that the permission applies to the
 
 
 class AndroidPath(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(category="manifest", name="android:path tag used", description=PATH_USAGE_DESCRIPTION)
-        super(AndroidPath, self).__init__(**kwargs)
+    def __init__(self):
+        super(AndroidPath, self).__init__(category="manifest", name="android:path tag used",
+                                          description=PATH_USAGE_DESCRIPTION)
+
         self.severity = Severity.WARNING
 
-    def run(self, **kwargs):
-        if not self.manifest_path:
-            return
-
+    def run(self):
         with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 if "android:path=" in line:

--- a/qark/plugins/manifest/android_path.py
+++ b/qark/plugins/manifest/android_path.py
@@ -15,7 +15,7 @@ class AndroidPath(ManifestPlugin):
         super(AndroidPath, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/android_path.py
+++ b/qark/plugins/manifest/android_path.py
@@ -15,7 +15,7 @@ class AndroidPath(ManifestPlugin):
         super(AndroidPath, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/api_keys.py
+++ b/qark/plugins/manifest/api_keys.py
@@ -14,15 +14,12 @@ API_KEY_DESCRIPTION = "Please confirm and investigate for potential API keys to 
 
 
 class APIKeys(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(category="manifest", name="Potential API Key found", description=API_KEY_DESCRIPTION)
-        super(APIKeys, self).__init__(**kwargs)
+    def __init__(self):
+        super(APIKeys, self).__init__(category="manifest", name="Potential API Key found",
+                                      description=API_KEY_DESCRIPTION)
         self.severity = Severity.INFO
 
-    def run(self, **kwargs):
-        if not self.manifest_path:
-            return
-
+    def run(self):
         with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 # TODO: Fix API_KEY_REGEX, there are too many false positives

--- a/qark/plugins/manifest/api_keys.py
+++ b/qark/plugins/manifest/api_keys.py
@@ -19,7 +19,7 @@ class APIKeys(ManifestPlugin):
         super(APIKeys, self).__init__(**kwargs)
         self.severity = Severity.INFO
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/api_keys.py
+++ b/qark/plugins/manifest/api_keys.py
@@ -19,7 +19,7 @@ class APIKeys(ManifestPlugin):
         super(APIKeys, self).__init__(**kwargs)
         self.severity = Severity.INFO
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/custom_permissions.py
+++ b/qark/plugins/manifest/custom_permissions.py
@@ -37,7 +37,7 @@ class CustomPermissions(ManifestPlugin):
 
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/custom_permissions.py
+++ b/qark/plugins/manifest/custom_permissions.py
@@ -37,7 +37,7 @@ class CustomPermissions(ManifestPlugin):
 
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, apk_constants=None, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/custom_permissions.py
+++ b/qark/plugins/manifest/custom_permissions.py
@@ -1,13 +1,9 @@
-from qark.plugins.manifest_helpers import get_min_sdk
 from qark.scanner.plugin import ManifestPlugin
-from qark.issue import Severity, Issue
 
 import logging
 
 from qark.issue import Severity, Issue
 from qark.plugins.manifest_helpers import get_min_sdk
-from qark.scanner.plugin import BasePlugin
-from qark.xml_helpers import get_manifest_out_of_files
 
 log = logging.getLogger(__name__)
 
@@ -26,21 +22,18 @@ DANGEROUS_PERMISSION_DESCRIPTION = (
 
 
 class CustomPermissions(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(dict(category="manifest", name="Custom permissions are enabled in the manifest",
-                           description=("This permission can be obtained by malicious apps installed prior to this "
-                                        "one, without the proper signature. Applicable to Android Devices prior to "
-                                        "L (Lollipop). More info: "
-                                        "https://github.com/commonsguy/cwac-security/blob/master/PERMS.md")))
-
-        super(CustomPermissions, self).__init__(**kwargs)
+    def __init__(self):
+        super(CustomPermissions, self).__init__(category="manifest",
+                                                name="Custom permissions are enabled in the manifest",
+                                                description=(
+                                                    "This permission can be obtained by malicious apps installed prior to this "
+                                                    "one, without the proper signature. Applicable to Android Devices prior to "
+                                                    "L (Lollipop). More info: "
+                                                    "https://github.com/commonsguy/cwac-security/blob/master/PERMS.md"))
 
         self.severity = Severity.WARNING
 
-    def run(self, apk_constants=None, **kwargs):
-        if not self.manifest_xml:
-            return
-
+    def run(self):
         permission_sections = self.manifest_xml.getElementsByTagName("permission")
         for permission in permission_sections:
             try:
@@ -49,7 +42,7 @@ class CustomPermissions(ManifestPlugin):
                 continue
 
             if protection_level in ("signature", "signatureOrSystem"):
-                if "min_sdk" in apk_constants or get_min_sdk(self.manifest_xml) < 21:
+                if self.min_sdk < 21:
                     self.issues.append(Issue(category=self.category,
                                              severity=SIGNATURE_OR_SIGNATURE_OR_SYSTEM_SEVERITY,
                                              name=self.name,

--- a/qark/plugins/manifest/debuggable.py
+++ b/qark/plugins/manifest/debuggable.py
@@ -20,7 +20,7 @@ class DebuggableManifest(ManifestPlugin):
 
         self.severity = Severity.VULNERABILITY
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/debuggable.py
+++ b/qark/plugins/manifest/debuggable.py
@@ -7,23 +7,20 @@ log = logging.getLogger(__name__)
 
 
 class DebuggableManifest(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(dict(category="manifest", name="Manifest is manually set to debug",
-                           description=("The android:debuggable flag is manually set to true in the"
-                                        " AndroidManifest.xml. This will cause your application to be debuggable "
-                                        "in production builds and can result in data leakage "
-                                        "and other security issues. It is not necessary to set the "
-                                        "android:debuggable flag in the manifest, it will be set appropriately "
-                                        "automatically by the tools. More info: "
-                                        "http://developer.android.com/guide/topics/manifest/application-element.html#debug")))
-        super(DebuggableManifest, self).__init__(**kwargs)
+    def __init__(self):
+        super(DebuggableManifest, self).__init__(category="manifest", name="Manifest is manually set to debug",
+                                                 description=(
+                                                     "The android:debuggable flag is manually set to true in the"
+                                                     " AndroidManifest.xml. This will cause your application to be debuggable "
+                                                     "in production builds and can result in data leakage "
+                                                     "and other security issues. It is not necessary to set the "
+                                                     "android:debuggable flag in the manifest, it will be set appropriately "
+                                                     "automatically by the tools. More info: "
+                                                     "http://developer.android.com/guide/topics/manifest/application-element.html#debug"))
 
         self.severity = Severity.VULNERABILITY
 
-    def run(self, **kwargs):
-        if not self.manifest_xml:
-            return
-
+    def run(self):
         application_sections = self.manifest_xml.getElementsByTagName("application")
         for application in application_sections:
             try:

--- a/qark/plugins/manifest/debuggable.py
+++ b/qark/plugins/manifest/debuggable.py
@@ -20,7 +20,7 @@ class DebuggableManifest(ManifestPlugin):
 
         self.severity = Severity.VULNERABILITY
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/exported_tags.py
+++ b/qark/plugins/manifest/exported_tags.py
@@ -212,7 +212,7 @@ class ExportedTags(ManifestPlugin):
         self.target_sdk = None
         self.package_name = None
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, apk_constants=None, all_files=None, **kwargs):
         if not self.manifest_xml:
             return
 
@@ -225,7 +225,7 @@ class ExportedTags(ManifestPlugin):
             for possibly_vulnerable_tag in all_tags_of_type_tag:
                 self._check_manifest_issues(possibly_vulnerable_tag, tag, self.manifest_path)
 
-        self._add_exported_tags_arguments_to_issue(list(java_files_from_files(files)))
+        self._add_exported_tags_arguments_to_issue(list(java_files_from_files(all_files)))
 
     def _check_manifest_issues(self, possibly_vulnerable_tag, tag, file_object):
         """
@@ -321,6 +321,7 @@ class ExportedTags(ManifestPlugin):
             self._get_arguments_for_method_from_file(java_files, issue, name_to_search_for=file_name)
 
     def _get_arguments_for_method_from_file(self, java_files, issue, name_to_search_for):
+        """Confusing code ported over from QARK v1. Used to get arguments for QARK's exploit APK."""
         added = False
         for java_file in java_files:
             if name_to_search_for not in java_file:

--- a/qark/plugins/manifest/exported_tags.py
+++ b/qark/plugins/manifest/exported_tags.py
@@ -210,9 +210,6 @@ class ExportedTags(ManifestPlugin):
         super(ExportedTags, self).__init__(category="manifest", name=EXPORTED_TAGS_ISSUE_NAME)
 
         self.bad_exported_tags = ("activity", "activity-alias", "service", "receiver", "provider")
-        self.min_sdk = None
-        self.target_sdk = None
-        self.package_name = None
 
     def run(self):
         for tag in self.bad_exported_tags:

--- a/qark/plugins/manifest/exported_tags.py
+++ b/qark/plugins/manifest/exported_tags.py
@@ -212,7 +212,7 @@ class ExportedTags(ManifestPlugin):
         self.target_sdk = None
         self.package_name = None
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_xml:
             return
 

--- a/qark/plugins/manifest/exported_tags.py
+++ b/qark/plugins/manifest/exported_tags.py
@@ -202,30 +202,25 @@ TAG_INFO = {"receiver": Receiver, "provider": Provider, "activity": Activity,
 
 
 class ExportedTags(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(dict(category="manifest", name=EXPORTED_TAGS_ISSUE_NAME))
+    all_files = None  # Put here to not break Liskov Substitution with the other ManifestPlugins
+    # This plugin is VERY abnormal from the other manifest plugins as it needs to search
+    #   java files in order to create the exploit APK. Be very careful around here.
 
-        super(ExportedTags, self).__init__(**kwargs)
+    def __init__(self):
+        super(ExportedTags, self).__init__(category="manifest", name=EXPORTED_TAGS_ISSUE_NAME)
 
         self.bad_exported_tags = ("activity", "activity-alias", "service", "receiver", "provider")
         self.min_sdk = None
         self.target_sdk = None
         self.package_name = None
 
-    def run(self, apk_constants=None, all_files=None, **kwargs):
-        if not self.manifest_xml:
-            return
-
-        self.min_sdk = apk_constants["min_sdk"] if "min_sdk" in apk_constants else get_min_sdk(self.manifest_xml)
-        self.target_sdk = apk_constants["target_sdk"] if "target_sdk" in apk_constants else get_target_sdk(self.manifest_xml)
-        self.package_name = apk_constants["package_name"] if "package_name" in apk_constants else get_package_from_manifest(self.manifest_path)
-
+    def run(self):
         for tag in self.bad_exported_tags:
             all_tags_of_type_tag = self.manifest_xml.getElementsByTagName(tag)
             for possibly_vulnerable_tag in all_tags_of_type_tag:
                 self._check_manifest_issues(possibly_vulnerable_tag, tag, self.manifest_path)
 
-        self._add_exported_tags_arguments_to_issue(list(java_files_from_files(all_files)))
+        self._add_exported_tags_arguments_to_issue(list(java_files_from_files(self.all_files)))
 
     def _check_manifest_issues(self, possibly_vulnerable_tag, tag, file_object):
         """

--- a/qark/plugins/manifest/min_sdk.py
+++ b/qark/plugins/manifest/min_sdk.py
@@ -21,12 +21,12 @@ class MinSDK(ManifestPlugin):
     """This plugin will create issues depending on the manifest's minimum SDK. For instance
     tapjacking is only protected when min_sdk > 9 (or custom code is used)."""
     def __init__(self, **kwargs):
-        kwargs.update(dict(category="manifest"))
+        kwargs.update(dict(name="MinSDK checks", category="manifest"))
         super(MinSDK, self).__init__(**kwargs)
 
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, apk_constants=None, **kwargs):
         try:
             min_sdk = apk_constants["min_sdk"]
         except (KeyError, TypeError):

--- a/qark/plugins/manifest/min_sdk.py
+++ b/qark/plugins/manifest/min_sdk.py
@@ -20,19 +20,13 @@ TAP_JACKING = ("Since the minSdkVersion is less that 9, it is likely this applic
 class MinSDK(ManifestPlugin):
     """This plugin will create issues depending on the manifest's minimum SDK. For instance
     tapjacking is only protected when min_sdk > 9 (or custom code is used)."""
-    def __init__(self, **kwargs):
-        kwargs.update(dict(name="MinSDK checks", category="manifest"))
-        super(MinSDK, self).__init__(**kwargs)
+    def __init__(self):
+        super(MinSDK, self).__init__(name="MinSDK checks", category="manifest")
 
         self.severity = Severity.WARNING
 
-    def run(self, apk_constants=None, **kwargs):
-        try:
-            min_sdk = apk_constants["min_sdk"]
-        except (KeyError, TypeError):
-            min_sdk = get_min_sdk(self.manifest_xml)
-
-        if min_sdk < 9:
+    def run(self):
+        if self.min_sdk < 9:
             self.issues.append(Issue(category=self.category, name="Tap Jacking possible",
                                      severity=Severity.VULNERABILITY, description=TAP_JACKING))
 

--- a/qark/plugins/manifest/min_sdk.py
+++ b/qark/plugins/manifest/min_sdk.py
@@ -26,7 +26,7 @@ class MinSDK(ManifestPlugin):
 
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         try:
             min_sdk = apk_constants["min_sdk"]
         except (KeyError, TypeError):

--- a/qark/plugins/manifest/single_task_launch_mode.py
+++ b/qark/plugins/manifest/single_task_launch_mode.py
@@ -19,7 +19,7 @@ class SingleTaskLaunchMode(ManifestPlugin):
         super(SingleTaskLaunchMode, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/single_task_launch_mode.py
+++ b/qark/plugins/manifest/single_task_launch_mode.py
@@ -19,7 +19,7 @@ class SingleTaskLaunchMode(ManifestPlugin):
         super(SingleTaskLaunchMode, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/single_task_launch_mode.py
+++ b/qark/plugins/manifest/single_task_launch_mode.py
@@ -2,7 +2,6 @@ import logging
 
 from qark.issue import Severity, Issue
 from qark.scanner.plugin import ManifestPlugin
-from qark.xml_helpers import get_manifest_out_of_files
 
 log = logging.getLogger(__name__)
 
@@ -14,15 +13,11 @@ TASK_LAUNCH_MODE_DESCRIPTION = (
 
 
 class SingleTaskLaunchMode(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(category="manifest", name="launchMode=singleTask found", description=TASK_LAUNCH_MODE_DESCRIPTION)
-        super(SingleTaskLaunchMode, self).__init__(**kwargs)
+    def __init__(self):
+        super(ManifestPlugin, self).__init__(category="manifest", name="launchMode=singleTask found", description=TASK_LAUNCH_MODE_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, **kwargs):
-        if not self.manifest_path:
-            return
-
+    def run(self):
         with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 if 'android:launchMode="singleTask"' in line:

--- a/qark/plugins/manifest/task_reparenting.py
+++ b/qark/plugins/manifest/task_reparenting.py
@@ -19,7 +19,7 @@ class TaskReparenting(ManifestPlugin):
         super(TaskReparenting, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None, **kwargs):
+    def run(self, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/task_reparenting.py
+++ b/qark/plugins/manifest/task_reparenting.py
@@ -19,7 +19,7 @@ class TaskReparenting(ManifestPlugin):
         super(TaskReparenting, self).__init__(**kwargs)
         self.severity = Severity.WARNING
 
-    def run(self, files, apk_constants=None):
+    def run(self, files, apk_constants=None, **kwargs):
         if not self.manifest_path:
             return
 

--- a/qark/plugins/manifest/task_reparenting.py
+++ b/qark/plugins/manifest/task_reparenting.py
@@ -13,16 +13,12 @@ TASK_REPARENTING_DESCRIPTION = (
 
 
 class TaskReparenting(ManifestPlugin):
-    def __init__(self, **kwargs):
-        kwargs.update(category="manifest", name="android:allowTaskReparenting='true' found",
-                      description=TASK_REPARENTING_DESCRIPTION)
-        super(TaskReparenting, self).__init__(**kwargs)
+    def __init__(self):
+        super(TaskReparenting, self).__init__(category="manifest", name="android:allowTaskReparenting='true' found",
+                                              description=TASK_REPARENTING_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, **kwargs):
-        if not self.manifest_path:
-            return
-
+    def run(self):
         with open(self.manifest_path, "r") as manifest_file:
             for line_number, line in enumerate(manifest_file):
                 if 'android:allowTaskReparenting="true"' in line:

--- a/qark/plugins/webview/add_javascript_interface.py
+++ b/qark/plugins/webview/add_javascript_interface.py
@@ -28,9 +28,10 @@ class AddJavascriptInterface(BasePlugin):
         self.java_method_name = "addJavascriptInterface"
 
     def run(self, filepath, apk_constants=None, java_ast=None, **kwargs):
-        min_sdk = apk_constants["min_sdk"]
-        if not java_ast:
+        if not java_ast or not apk_constants or not apk_constants.get("min_sdk"):
             return
+
+        min_sdk = apk_constants["min_sdk"]
 
         if min_sdk <= 16:
             for _, method_invocation in java_ast.filter(MethodInvocation):

--- a/qark/plugins/webview/add_javascript_interface.py
+++ b/qark/plugins/webview/add_javascript_interface.py
@@ -27,33 +27,17 @@ class AddJavascriptInterface(BasePlugin):
         self.severity = Severity.WARNING
         self.java_method_name = "addJavascriptInterface"
 
-    def _process(self, java_file, min_sdk):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
-            return
-
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
+    def run(self, filepath, apk_constants=None, java_ast=None, **kwargs):
+        min_sdk = apk_constants["min_sdk"]
+        if not java_ast:
             return
 
         if min_sdk <= 16:
-            for _, method_invocation in tree.filter(MethodInvocation):
+            for _, method_invocation in java_ast.filter(MethodInvocation):
                 if valid_method_invocation(method_invocation, method_name=self.java_method_name, num_arguments=2):
                     self.issues.append(Issue(category=self.category, name=self.name, severity=self.severity,
                                              description=self.description, line_number=method_invocation.position,
-                                             file_object=java_file))
-
-    def run(self, files, apk_constants=None):
-        min_sdk = get_min_sdk_from_files(files, apk_constants)
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file, min_sdk)
+                                             file_object=filepath))
 
 
 plugin = AddJavascriptInterface()

--- a/qark/plugins/webview/javascript_enabled.py
+++ b/qark/plugins/webview/javascript_enabled.py
@@ -23,8 +23,8 @@ JAVASCRIPT_ENABLED_DESCRIPTION = (
 class JavascriptEnabled(JavaASTPlugin):
     """This plugin checks if the `setJavaScriptEnabled` method is called with a value of `true`"""
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="webview", name="Javascript enabled in Webview",
-                               description=JAVASCRIPT_ENABLED_DESCRIPTION)
+        super(JavascriptEnabled, self).__init__(category="webview", name="Javascript enabled in Webview",
+                                                description=JAVASCRIPT_ENABLED_DESCRIPTION)
 
     def run(self):
         for _, method_invocation in self.java_ast.filter(MethodInvocation):

--- a/qark/plugins/webview/javascript_enabled.py
+++ b/qark/plugins/webview/javascript_enabled.py
@@ -26,30 +26,15 @@ class JavascriptEnabled(BasePlugin):
         BasePlugin.__init__(self, category="webview", name="Javascript enabled in Webview",
                             description=JAVASCRIPT_ENABLED_DESCRIPTION)
 
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, java_file, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        for _, method_invocation in tree.filter(MethodInvocation):
+        for _, method_invocation in java_ast.filter(MethodInvocation):
             if valid_set_method_bool(method_invocation, str_bool="true", method_name="setJavaScriptEnabled"):
                 self.issues.append(Issue(category=self.category, name=self.name, severity=Severity.WARNING,
                                          description=self.description, line_number=method_invocation.position,
                                          file_object=java_file))
-
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            self._process(java_file)
 
 
 plugin = JavascriptEnabled()

--- a/qark/plugins/webview/javascript_enabled.py
+++ b/qark/plugins/webview/javascript_enabled.py
@@ -6,7 +6,7 @@ from javalang.tree import MethodInvocation
 from qark.issue import Severity, Issue
 from qark.plugins.helpers import java_files_from_files
 from qark.plugins.webview.helpers import valid_set_method_bool
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -20,21 +20,18 @@ JAVASCRIPT_ENABLED_DESCRIPTION = (
 )
 
 
-class JavascriptEnabled(BasePlugin):
+class JavascriptEnabled(JavaASTPlugin):
     """This plugin checks if the `setJavaScriptEnabled` method is called with a value of `true`"""
     def __init__(self):
-        BasePlugin.__init__(self, category="webview", name="Javascript enabled in Webview",
-                            description=JAVASCRIPT_ENABLED_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="webview", name="Javascript enabled in Webview",
+                               description=JAVASCRIPT_ENABLED_DESCRIPTION)
 
-    def run(self, java_file, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        for _, method_invocation in java_ast.filter(MethodInvocation):
+    def run(self):
+        for _, method_invocation in self.java_ast.filter(MethodInvocation):
             if valid_set_method_bool(method_invocation, str_bool="true", method_name="setJavaScriptEnabled"):
                 self.issues.append(Issue(category=self.category, name=self.name, severity=Severity.WARNING,
                                          description=self.description, line_number=method_invocation.position,
-                                         file_object=java_file))
+                                         file_object=self.file_path))
 
 
 plugin = JavascriptEnabled()

--- a/qark/plugins/webview/load_data_with_base_url.py
+++ b/qark/plugins/webview/load_data_with_base_url.py
@@ -23,30 +23,15 @@ class LoadDataWithBaseURL(BasePlugin):
         BasePlugin.__init__(self, category="webview", name="BaseURL set for Webview",
                             description=LOAD_DATA_WITH_BASE_URL_DESCRIPTION)
 
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        for _, method_invocation in tree.filter(MethodInvocation):
+        for _, method_invocation in java_ast.filter(MethodInvocation):
             if method_invocation.member == "loadDataWithBaseURL" and len(method_invocation.arguments) == 5:
                 self.issues.append(Issue(category=self.category, name=self.name, severity=Severity.WARNING,
                                          description=self.description, line_number=method_invocation.position,
-                                         file_object=java_file))
-
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            self._process(java_file)
+                                         file_object=filepath))
 
 
 plugin = LoadDataWithBaseURL()

--- a/qark/plugins/webview/load_data_with_base_url.py
+++ b/qark/plugins/webview/load_data_with_base_url.py
@@ -1,11 +1,9 @@
 import logging
 
-import javalang
 from javalang.tree import MethodInvocation
 
 from qark.issue import Severity, Issue
-from qark.plugins.helpers import java_files_from_files
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -17,21 +15,18 @@ LOAD_DATA_WITH_BASE_URL_DESCRIPTION = (
 )
 
 
-class LoadDataWithBaseURL(BasePlugin):
+class LoadDataWithBaseURL(JavaASTPlugin):
     """This plugin checks if the `loadDataWithBaseURL` method is called."""
     def __init__(self):
-        BasePlugin.__init__(self, category="webview", name="BaseURL set for Webview",
-                            description=LOAD_DATA_WITH_BASE_URL_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="webview", name="BaseURL set for Webview",
+                               description=LOAD_DATA_WITH_BASE_URL_DESCRIPTION)
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        for _, method_invocation in java_ast.filter(MethodInvocation):
+    def run(self):
+        for _, method_invocation in self.java_ast.filter(MethodInvocation):
             if method_invocation.member == "loadDataWithBaseURL" and len(method_invocation.arguments) == 5:
                 self.issues.append(Issue(category=self.category, name=self.name, severity=Severity.WARNING,
                                          description=self.description, line_number=method_invocation.position,
-                                         file_object=filepath))
+                                         file_object=self.file_path))
 
 
 plugin = LoadDataWithBaseURL()

--- a/qark/plugins/webview/load_data_with_base_url.py
+++ b/qark/plugins/webview/load_data_with_base_url.py
@@ -18,8 +18,8 @@ LOAD_DATA_WITH_BASE_URL_DESCRIPTION = (
 class LoadDataWithBaseURL(JavaASTPlugin):
     """This plugin checks if the `loadDataWithBaseURL` method is called."""
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="webview", name="BaseURL set for Webview",
-                               description=LOAD_DATA_WITH_BASE_URL_DESCRIPTION)
+        super(LoadDataWithBaseURL, self).__init__(category="webview", name="BaseURL set for Webview",
+                                                  description=LOAD_DATA_WITH_BASE_URL_DESCRIPTION)
 
     def run(self):
         for _, method_invocation in self.java_ast.filter(MethodInvocation):

--- a/qark/plugins/webview/set_allow_content_access.py
+++ b/qark/plugins/webview/set_allow_content_access.py
@@ -1,11 +1,8 @@
 import logging
 
-import javalang
-
 from qark.issue import Severity
-from qark.plugins.helpers import java_files_from_files
 from qark.plugins.webview.helpers import webview_default_vulnerable
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -17,21 +14,18 @@ SET_ALLOW_CONTENT_ACCESS_DESCRIPTION = (
 )
 
 
-class SetAllowContentAccess(BasePlugin):
+class SetAllowContentAccess(JavaASTPlugin):
     """This plugin checks if the webview calls setAllowContentAccess(false), otherwise the webview is vulnerable
     (defaults to true)."""
     def __init__(self):
-        BasePlugin.__init__(self, category="webview", name="Webview enables content access",
-                            description=SET_ALLOW_CONTENT_ACCESS_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="webview", name="Webview enables content access",
+                               description=SET_ALLOW_CONTENT_ACCESS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        self.issues.extend(webview_default_vulnerable(java_ast, method_name="setAllowContentAccess",
+    def run(self):
+        self.issues.extend(webview_default_vulnerable(self.java_ast, method_name="setAllowContentAccess",
                                                       issue_name=self.name,
-                                                      description=self.description, file_object=filepath,
+                                                      description=self.description, file_object=self.file_path,
                                                       severity=self.severity))
 
 

--- a/qark/plugins/webview/set_allow_content_access.py
+++ b/qark/plugins/webview/set_allow_content_access.py
@@ -25,28 +25,14 @@ class SetAllowContentAccess(BasePlugin):
                             description=SET_ALLOW_CONTENT_ACCESS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        self.issues.extend(webview_default_vulnerable(tree, method_name="setAllowContentAccess", issue_name=self.name,
-                                                      description=self.description, file_object=java_file,
+        self.issues.extend(webview_default_vulnerable(java_ast, method_name="setAllowContentAccess",
+                                                      issue_name=self.name,
+                                                      description=self.description, file_object=filepath,
                                                       severity=self.severity))
-
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            self._process(java_file)
 
 
 plugin = SetAllowContentAccess()

--- a/qark/plugins/webview/set_allow_content_access.py
+++ b/qark/plugins/webview/set_allow_content_access.py
@@ -18,8 +18,8 @@ class SetAllowContentAccess(JavaASTPlugin):
     """This plugin checks if the webview calls setAllowContentAccess(false), otherwise the webview is vulnerable
     (defaults to true)."""
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="webview", name="Webview enables content access",
-                               description=SET_ALLOW_CONTENT_ACCESS_DESCRIPTION)
+        super(SetAllowContentAccess, self).__init__(category="webview", name="Webview enables content access",
+                                                    description=SET_ALLOW_CONTENT_ACCESS_DESCRIPTION)
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/webview/set_allow_file_access.py
+++ b/qark/plugins/webview/set_allow_file_access.py
@@ -1,11 +1,8 @@
 import logging
 
-import javalang
-
 from qark.issue import Severity
-from qark.plugins.helpers import java_files_from_files
 from qark.plugins.webview.helpers import webview_default_vulnerable
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -17,20 +14,17 @@ SET_ALLOW_FILE_ACCESS_DESCRIPTION = (
 )
 
 
-class SetAllowFileAccess(BasePlugin):
+class SetAllowFileAccess(JavaASTPlugin):
     """This plugin checks if the webview calls setAllowFileAccess(false), otherwise the webview is vulnerable
     (defaults to true)."""
     def __init__(self):
-        BasePlugin.__init__(self, category="webview", name="Webview enables file access",
-                            description=SET_ALLOW_FILE_ACCESS_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="webview", name="Webview enables file access",
+                               description=SET_ALLOW_FILE_ACCESS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        self.issues.extend(webview_default_vulnerable(java_ast, method_name="setAllowFileAccess", issue_name=self.name,
-                                                      description=self.description, file_object=filepath,
+    def run(self):
+        self.issues.extend(webview_default_vulnerable(self.java_ast, method_name="setAllowFileAccess", issue_name=self.name,
+                                                      description=self.description, file_object=self.file_path,
                                                       severity=self.severity))
 
 

--- a/qark/plugins/webview/set_allow_file_access.py
+++ b/qark/plugins/webview/set_allow_file_access.py
@@ -25,28 +25,13 @@ class SetAllowFileAccess(BasePlugin):
                             description=SET_ALLOW_FILE_ACCESS_DESCRIPTION)
         self.severity = Severity.WARNING
 
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        self.issues.extend(webview_default_vulnerable(tree, method_name="setAllowFileAccess", issue_name=self.name,
-                                                      description=self.description, file_object=java_file,
+        self.issues.extend(webview_default_vulnerable(java_ast, method_name="setAllowFileAccess", issue_name=self.name,
+                                                      description=self.description, file_object=filepath,
                                                       severity=self.severity))
-
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            self._process(java_file)
 
 
 plugin = SetAllowFileAccess()

--- a/qark/plugins/webview/set_allow_file_access.py
+++ b/qark/plugins/webview/set_allow_file_access.py
@@ -18,8 +18,8 @@ class SetAllowFileAccess(JavaASTPlugin):
     """This plugin checks if the webview calls setAllowFileAccess(false), otherwise the webview is vulnerable
     (defaults to true)."""
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="webview", name="Webview enables file access",
-                               description=SET_ALLOW_FILE_ACCESS_DESCRIPTION)
+        super(SetAllowFileAccess, self).__init__(category="webview", name="Webview enables file access",
+                                                 description=SET_ALLOW_FILE_ACCESS_DESCRIPTION)
         self.severity = Severity.WARNING
 
     def run(self):

--- a/qark/plugins/webview/set_allow_universal_access_from_file_urls.py
+++ b/qark/plugins/webview/set_allow_universal_access_from_file_urls.py
@@ -1,12 +1,10 @@
 import logging
 
-import javalang
 from javalang.tree import MethodInvocation
 
 from qark.issue import Issue, Severity
-from qark.plugins.helpers import java_files_from_files, get_min_sdk_from_files
 from qark.plugins.webview.helpers import webview_default_vulnerable, valid_set_method_bool
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin, ManifestPlugin
 
 log = logging.getLogger(__name__)
 
@@ -18,30 +16,27 @@ SET_ALLOW_UNIVERSAL_ACCESS_FROM_FILE_URLS_DESCRIPTION = (
 )
 
 
-class SetAllowUniversalAccessFromFileURLs(BasePlugin):
+class SetAllowUniversalAccessFromFileURLs(JavaASTPlugin, ManifestPlugin):
     """This plugin checks if the `setAllowUniversalAccessFromFileURLs` method is called with a value of `true`, or
     if the default is vulnerable."""
     def __init__(self):
-        BasePlugin.__init__(self, category="webview", name="Webview enables universal access for JavaScript",
-                            description=SET_ALLOW_UNIVERSAL_ACCESS_FROM_FILE_URLS_DESCRIPTION)
+        super(SetAllowUniversalAccessFromFileURLs, self).__init__(category="webview",
+                                                                  name="Webview enables universal access for JavaScript",
+                                                                  description=SET_ALLOW_UNIVERSAL_ACCESS_FROM_FILE_URLS_DESCRIPTION)
         self.severity = Severity.WARNING
         self.java_method_name = "setAllowUniversalAccessFromFileURLs"
 
-    def run(self, filepath, apk_constants=None, java_ast=None, **kwargs):
-        if not apk_constants or not apk_constants.get("min_sdk") or not java_ast:
-            return
-
-        min_sdk = apk_constants["min_sdk"]
-        if min_sdk <= 15:
-            self.issues.extend(webview_default_vulnerable(java_ast, method_name=self.java_method_name,
+    def run(self):
+        if self.min_sdk <= 15:
+            self.issues.extend(webview_default_vulnerable(self.java_ast, method_name=self.java_method_name,
                                                           issue_name=self.name, description=self.description,
-                                                          file_object=filepath, severity=self.severity))
+                                                          file_object=self.file_path, severity=self.severity))
         else:
-            for _, method_invocation in java_ast.filter(MethodInvocation):
+            for _, method_invocation in self.java_ast.filter(MethodInvocation):
                 if valid_set_method_bool(method_invocation, str_bool="true", method_name=self.java_method_name):
                     self.issues.append(Issue(category=self.category, name=self.name, severity=self.severity,
                                              description=self.description, line_number=method_invocation.position,
-                                             file_object=filepath))
+                                             file_object=self.file_path))
 
 
 plugin = SetAllowUniversalAccessFromFileURLs()

--- a/qark/plugins/webview/set_allow_universal_access_from_file_urls.py
+++ b/qark/plugins/webview/set_allow_universal_access_from_file_urls.py
@@ -28,7 +28,7 @@ class SetAllowUniversalAccessFromFileURLs(BasePlugin):
         self.java_method_name = "setAllowUniversalAccessFromFileURLs"
 
     def run(self, filepath, apk_constants=None, java_ast=None, **kwargs):
-        if not apk_constants.get("min_sdk") or not java_ast:
+        if not apk_constants or not apk_constants.get("min_sdk") or not java_ast:
             return
 
         min_sdk = apk_constants["min_sdk"]

--- a/qark/plugins/webview/set_allow_universal_access_from_file_urls.py
+++ b/qark/plugins/webview/set_allow_universal_access_from_file_urls.py
@@ -27,37 +27,21 @@ class SetAllowUniversalAccessFromFileURLs(BasePlugin):
         self.severity = Severity.WARNING
         self.java_method_name = "setAllowUniversalAccessFromFileURLs"
 
-    def _process(self, java_file, min_sdk):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, apk_constants=None, java_ast=None, **kwargs):
+        if not apk_constants.get("min_sdk") or not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
+        min_sdk = apk_constants["min_sdk"]
         if min_sdk <= 15:
-            self.issues.extend(webview_default_vulnerable(tree, method_name=self.java_method_name,
+            self.issues.extend(webview_default_vulnerable(java_ast, method_name=self.java_method_name,
                                                           issue_name=self.name, description=self.description,
-                                                          file_object=java_file, severity=self.severity))
+                                                          file_object=filepath, severity=self.severity))
         else:
-            for _, method_invocation in tree.filter(MethodInvocation):
+            for _, method_invocation in java_ast.filter(MethodInvocation):
                 if valid_set_method_bool(method_invocation, str_bool="true", method_name=self.java_method_name):
                     self.issues.append(Issue(category=self.category, name=self.name, severity=self.severity,
                                              description=self.description, line_number=method_invocation.position,
-                                             file_object=java_file))
-
-    def run(self, files, apk_constants=None):
-        min_sdk = get_min_sdk_from_files(files, apk_constants)
-        java_files = java_files_from_files(files)
-
-        for java_file in java_files:
-            self._process(java_file, min_sdk)
+                                             file_object=filepath))
 
 
 plugin = SetAllowUniversalAccessFromFileURLs()

--- a/qark/plugins/webview/set_dom_storage_enabled.py
+++ b/qark/plugins/webview/set_dom_storage_enabled.py
@@ -23,30 +23,15 @@ class SetDomStorageEnabled(BasePlugin):
         self.severity = Severity.WARNING
         self.java_method_name = "setDomStorageEnabled"
 
-    def _process(self, java_file):
-        try:
-            with open(java_file, "r") as java_file_to_read:
-                file_contents = java_file_to_read.read()
-        except IOError:
-            log.debug("File does not exist %s, continuing", java_file)
+    def run(self, filepath, java_ast=None, **kwargs):
+        if not java_ast:
             return
 
-        try:
-            tree = javalang.parse.parse(file_contents)
-        except (javalang.parser.JavaSyntaxError, IndexError):
-            log.debug("Error parsing file %s, continuing", java_file)
-            return
-
-        for _, method_invocation in tree.filter(MethodInvocation):
+        for _, method_invocation in java_ast.filter(MethodInvocation):
             if valid_set_method_bool(method_invocation, str_bool="true", method_name=self.java_method_name):
                 self.issues.append(Issue(category=self.category, name=self.name, severity=self.severity,
                                          description=self.description, line_number=method_invocation.position,
-                                         file_object=java_file))
-
-    def run(self, files, apk_constants=None):
-        java_files = java_files_from_files(files)
-        for java_file in java_files:
-            self._process(java_file)
+                                         file_object=filepath))
 
 
 plugin = SetDomStorageEnabled()

--- a/qark/plugins/webview/set_dom_storage_enabled.py
+++ b/qark/plugins/webview/set_dom_storage_enabled.py
@@ -16,8 +16,8 @@ SET_DOM_STORAGE_ENABLED_DESCRIPTION = (
 class SetDomStorageEnabled(JavaASTPlugin):
     """This plugin checks if the `setDomStorageEnabled` method is called with a value of `true`."""
     def __init__(self):
-        JavaASTPlugin.__init__(self, category="webview", name="Webview enables DOM Storage",
-                               description=SET_DOM_STORAGE_ENABLED_DESCRIPTION)
+        super(SetDomStorageEnabled, self).__init__(category="webview", name="Webview enables DOM Storage",
+                                                   description=SET_DOM_STORAGE_ENABLED_DESCRIPTION)
         self.severity = Severity.WARNING
         self.java_method_name = "setDomStorageEnabled"
 

--- a/qark/plugins/webview/set_dom_storage_enabled.py
+++ b/qark/plugins/webview/set_dom_storage_enabled.py
@@ -1,12 +1,10 @@
 import logging
 
-import javalang
 from javalang.tree import MethodInvocation
 
 from qark.issue import Issue, Severity
-from qark.plugins.helpers import java_files_from_files
 from qark.plugins.webview.helpers import valid_set_method_bool
-from qark.scanner.plugin import BasePlugin
+from qark.scanner.plugin import JavaASTPlugin
 
 log = logging.getLogger(__name__)
 
@@ -15,23 +13,20 @@ SET_DOM_STORAGE_ENABLED_DESCRIPTION = (
 )
 
 
-class SetDomStorageEnabled(BasePlugin):
+class SetDomStorageEnabled(JavaASTPlugin):
     """This plugin checks if the `setDomStorageEnabled` method is called with a value of `true`."""
     def __init__(self):
-        BasePlugin.__init__(self, category="webview", name="Webview enables DOM Storage",
-                            description=SET_DOM_STORAGE_ENABLED_DESCRIPTION)
+        JavaASTPlugin.__init__(self, category="webview", name="Webview enables DOM Storage",
+                               description=SET_DOM_STORAGE_ENABLED_DESCRIPTION)
         self.severity = Severity.WARNING
         self.java_method_name = "setDomStorageEnabled"
 
-    def run(self, filepath, java_ast=None, **kwargs):
-        if not java_ast:
-            return
-
-        for _, method_invocation in java_ast.filter(MethodInvocation):
+    def run(self):
+        for _, method_invocation in self.java_ast.filter(MethodInvocation):
             if valid_set_method_bool(method_invocation, str_bool="true", method_name=self.java_method_name):
                 self.issues.append(Issue(category=self.category, name=self.name, severity=self.severity,
                                          description=self.description, line_number=method_invocation.position,
-                                         file_object=filepath))
+                                         file_object=self.file_path))
 
 
 plugin = SetDomStorageEnabled()

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -68,7 +68,7 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk):
     click.secho("Writing report...")
     report = Report(issues=set(scanner.issues))
     report_path = report.generate(file_type=report_type)
-    click.secho("Finish writing report to {report_path}...".format(report_path=report_path))
+    click.secho("Finish writing report to {report_path} ...".format(report_path=report_path))
 
     if exploit_apk:
         click.secho("Building exploit APK...")

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -95,7 +95,6 @@ class FilePathPlugin(PluginObserver):
         :param str file_path:
         :param bool call_run: Whether or not `self.run()` should be called. Prevents `run()` being called multiple times
         """
-        print("in file path update: ", file_path)
         if not file_path:
             FilePathPlugin.file_path = None
             return

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -4,6 +4,9 @@ import logging
 from xml.dom import minidom
 
 from pluginbase import PluginBase
+import javalang
+from qark.utils import is_java_file
+from qark.plugins.manifest_helpers import get_min_sdk, get_target_sdk, get_package_from_manifest
 
 log = logging.getLogger(__name__)
 
@@ -57,7 +60,7 @@ class BasePlugin(object):
         self.issues = []
 
     @abc.abstractmethod
-    def run(self, file, **kwargs):
+    def run(self):
         """
         Method to be called for each plugin to add issues.
 
@@ -68,30 +71,129 @@ class BasePlugin(object):
         pass
 
 
+class PluginObserver(BasePlugin):
+    __metaclass__ = abc.ABCMeta
+
+    @abc.abstractmethod
+    def update(self, *args, **kwargs):
+        """For plugins to implement."""
+
+    @abc.abstractmethod
+    def reset(self):
+        """Clear any class attributes that were set for the file."""
+
+
+class FilePathPlugin(PluginObserver):
+    """Subclass this plugin if your plugin needs action based on a new file path."""
+    __metaclass__ = abc.ABCMeta
+
+    file_path = None
+    has_been_set = False
+
+    def update(self, file_path, call_run=False):
+        """
+        :param str file_path:
+        :param bool call_run: Whether or not `self.run()` should be called. Prevents `run()` being called multiple times
+        """
+        print("in file path update: ", file_path)
+        if not file_path:
+            FilePathPlugin.file_path = None
+            return
+
+        if not self.has_been_set:
+            FilePathPlugin.file_path = file_path
+            FilePathPlugin.has_been_set = True
+
+        if call_run:
+            self.run()
+
+    @classmethod
+    def reset(cls):
+        FilePathPlugin.file_path = None
+        FilePathPlugin.has_been_set = False
+
+
+class FileContentsPlugin(FilePathPlugin):
+    """Subclass this plugin if your plugin needs to operate on file contents and no other plugin type suffices."""
+    __metaclass__ = abc.ABCMeta
+
+    file_contents = None
+    readable = True
+
+    def update(self, file_path, call_run=False):
+        """
+        If `file_contents` is None, then the file has not been read yet, and we must set it.
+        If the file is not able to be read then we set a flag telling other plugins to not try to operate on it.
+        """
+        if not self.readable:
+            return
+
+        if self.file_contents is None:
+            # Make sure the file path has been set.
+            super(FileContentsPlugin, self).update(file_path)
+
+            try:
+                with open(self.file_path, "r") as f:
+                    FileContentsPlugin.file_contents = f.read()
+            except IOError:
+                log.debug("Unable to operate on file %s for reading", self.file_path)
+                FileContentsPlugin.readable = False
+                FileContentsPlugin.file_contents = None
+                return
+
+        if call_run and self.file_contents is not None:
+            self.run()
+
+    @classmethod
+    def reset(cls):
+        FileContentsPlugin.file_contents = None
+        FileContentsPlugin.readable = True
+
+        super(FileContentsPlugin, cls).reset()
+
+
+class JavaASTPlugin(FileContentsPlugin):
+    __metaclass__ = abc.ABCMeta
+
+    java_ast = None
+    parseable = True
+
+    def update(self, file_path, call_run=False):
+        if not self.parseable:
+            return
+
+        if self.java_ast is None:
+            # Make sure the file contents have been set
+            super(JavaASTPlugin, self).update(file_path, call_run=False)
+
+            if self.file_contents and is_java_file(self.file_path):
+                try:
+                    JavaASTPlugin.java_ast = javalang.parse.parse(self.file_contents)
+                except (javalang.parser.JavaSyntaxError, IndexError):
+                    log.debug("Unable to parse AST for file %s", self.file_path)
+                    JavaASTPlugin.java_ast = None
+                    JavaASTPlugin.parseable = False
+                    return
+
+        if call_run and self.java_ast is not None:
+            self.run()
+
+    @classmethod
+    def reset(cls):
+        JavaASTPlugin.java_ast = None
+        JavaASTPlugin.parseable = True
+
+        super(JavaASTPlugin, cls).reset()
+
+
 class ManifestPlugin(BasePlugin):
+    __metaclass__ = abc.ABCMeta
+
     manifest_xml = None
     manifest_path = None
-
-    def __init__(self, manifest_path=None, manifest_xml=None, **kwargs):
-        if self.manifest_path is None:
-            self.manifest_path = manifest_path
-
-        if self.manifest_xml is None:
-            try:
-                # If the user passed the parsed minidom XML content then we don't have to parse anything
-                self.manifest_xml = manifest_xml
-
-            except KeyError:
-
-                # Otherwise we have to get the manifest path and parse it
-                try:
-                    self.manifest_xml = minidom.parse(self.manifest_path)
-
-                except Exception:
-                    log.debug("Failed to parse the XML file, resetting manifest_path")
-                    self.manifest_path = None
-
-        super(ManifestPlugin, self).__init__(**kwargs)
+    min_sdk = -1
+    target_sdk = -1
+    package_name = "PACKAGE_NOT_FOUND"
 
     @classmethod
     def update_manifest(cls, path_to_manifest):
@@ -102,7 +204,21 @@ class ManifestPlugin(BasePlugin):
         except Exception:
             # path_to_manifest is None or has bad XML
             cls.manifest_xml = None
+            log.debug("Failed to update manifest for file %s", path_to_manifest)
+            return
+
+        try:
+            cls.min_sdk = get_min_sdk(cls.manifest_path)
+            cls.target_sdk = get_target_sdk(cls.manifest_path)
+        except AttributeError:
+            # manifest path is not set, assume min_sdk and target_sdk
+            cls.min_sdk = cls.target_sdk = 1
+
+        try:
+            cls.package_name = get_package_from_manifest(cls.manifest_path)
+        except IOError:
+            cls.package_name = "PACKAGE_NOT_FOUND"
 
     @abc.abstractmethod
-    def run(self, files, apk_constants=None):
+    def run(self):
         """User should define how their plugin runs"""

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -47,7 +47,7 @@ def get_plugins(category=None):
 class BasePlugin(object):
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, category=None, name=None, description=None, **kwargs):
+    def __init__(self, name, category, description=None, **kwargs):
         self.category = category
         self.name = name
         self.description = description

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -25,7 +25,7 @@ def get_plugin_source(category=None):
         path = os.path.join(path, category)
 
     try:
-        return plugin_base.make_plugin_source(searchpath=[path])
+        return plugin_base.make_plugin_source(searchpath=[path], persist=True)
     except Exception:
         log.exception("Failed to get all plugins. Is the file path to plugins %s correct?", path)
         raise SystemExit("Failed to get all plugins. Is the file path correct?")

--- a/qark/scanner/plugin.py
+++ b/qark/scanner/plugin.py
@@ -57,7 +57,7 @@ class BasePlugin(object):
         self.issues = []
 
     @abc.abstractmethod
-    def run(self, files, apk_constants=None):
+    def run(self, file, **kwargs):
         """
         Method to be called for each plugin to add issues.
 

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -51,11 +51,11 @@ class Scanner(object):
                 ManifestPlugin.update_manifest(self.manifest_path)
                 if ManifestPlugin.manifest_xml is not None:
 
-                    # Give more detail to the ExportedTags manifest plugin as it is important for building the exploit
-                    #   APK. Careful!
-                    ExportedTags.all_files = self.files
+                    for plugin in [plugin_source.load_plugin(plugin_name).plugin for plugin_name in manifest_plugins]:
+                        # Give more detail to the ExportedTags manifest plugin as it is important for building the exploit
+                        #   APK. Careful!
+                        plugin.all_files = self.files
 
-                    for plugin in (plugin_source.load_plugin(plugin_name).plugin for plugin_name in manifest_plugins):
                         plugin.run()
                         self.issues.extend(plugin.issues)
                     continue
@@ -106,8 +106,10 @@ class Scanner(object):
         """Walks the `Decompiler.build_directory` and updates the `self.files` set with new files."""
         if is_java_file(self.path_to_source):
             self.files.add(self.path_to_source)
+            log.debug("Added single java file to scanner")
             return
 
+        log.debug("Adding files to scanner...")
         try:
             for (dir_path, _, file_names) in walk(self.build_directory):
                 for file_name in file_names:

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -6,11 +6,12 @@ from os import (
     path
 )
 
-import javalang
-from qark.plugins.manifest_helpers import get_min_sdk, get_target_sdk, get_package_from_manifest
+from qark.scanner.plugin import PluginObserver
 from qark.scanner.plugin import get_plugin_source, get_plugins
 from qark.scanner.plugin import ManifestPlugin
+from qark.plugins.manifest.exported_tags import ExportedTags
 from qark.xml_helpers import get_manifest_out_of_files
+from qark.utils import is_java_file
 
 log = logging.getLogger(__name__)
 
@@ -31,28 +32,10 @@ class Scanner(object):
         self.issues = []
         self.manifest_path = manifest_path
 
-        # Manifest plugins should be able to retrieve the manifest xml directly
-        ManifestPlugin.update_manifest(manifest_path)
-
         self.path_to_source = path_to_source
         self.build_directory = build_directory
 
         self._gather_files()
-        try:
-            min_sdk = get_min_sdk(self.manifest_path, files=self.files)
-            target_sdk = get_target_sdk(self.manifest_path, files=self.files)
-        except AttributeError:
-            # manifest path is not set, assume min_sdk and target_sdk
-            min_sdk = target_sdk = 1
-
-        try:
-            package_name = get_package_from_manifest(self.manifest_path)
-        except IOError:
-            package_name = "PACKAGE_NOT_FOUND"
-
-        self.apk_constants = {"min_sdk": min_sdk,
-                              "target_sdk": target_sdk,
-                              "package_name": package_name}
 
     def run(self):
         """
@@ -65,12 +48,17 @@ class Scanner(object):
             if category == "manifest":
                 # Manifest plugins only need to run once, so we run them and continue
                 manifest_plugins = get_plugins(category)
+                ManifestPlugin.update_manifest(self.manifest_path)
+                if ManifestPlugin.manifest_xml is not None:
 
-                for plugin in (plugin_source.load_plugin(plugin_name).plugin for plugin_name in manifest_plugins):
-                    plugin.run(all_files=self.files,
-                               apk_constants=self.apk_constants)
-                    self.issues.extend(plugin.issues)
-                continue
+                    # Give more detail to the ExportedTags manifest plugin as it is important for building the exploit
+                    #   APK. Careful!
+                    ExportedTags.all_files = self.files
+
+                    for plugin in (plugin_source.load_plugin(plugin_name).plugin for plugin_name in manifest_plugins):
+                        plugin.run()
+                        self.issues.extend(plugin.issues)
+                    continue
 
             for plugin_name in get_plugins(category):
                 plugins.append(plugin_source.load_plugin(plugin_name).plugin)
@@ -79,36 +67,44 @@ class Scanner(object):
 
     def _run_checks(self, plugins):
         """Run all the plugins (besides manifest) on every file."""
+        current_file_subject = Subject()
+        for plugin in (observer_plugin for observer_plugin in plugins if isinstance(observer_plugin, PluginObserver)):
+            current_file_subject.register(plugin)
+
         for filepath in self.files:
-            ast = None
+            current_file_subject.notify(filepath)  # All the plugins will be running now
+            # reset the plugin file data to None
+            current_file_subject.reset()
 
-            try:
-                with open(filepath, 'r') as f:
-                    file_contents = f.read()
-            except Exception:
-                log.exception("Unable to read file %s", filepath)
-                file_contents = None
-
-            if file_contents and filepath.lower().endswith(".java"):
-                try:
-                    ast = javalang.parse.parse(file_contents)
-                except (javalang.parser.JavaSyntaxError, IndexError):
-                    log.debug("Unable to parse AST for file %s", filepath)
-
-            for plugin in plugins:
-                log.debug("Running plugin %s", plugin.name)
-                plugin.run(filepath,
-                           apk_constants=self.apk_constants,
-                           java_ast=ast,
-                           file_contents=file_contents,
-                           all_files=self.files)
-
-        for plugin in plugins:
-            self.issues.extend(plugin.issues)
+        #     ast = None
+        #
+        #     try:
+        #         with open(filepath, 'r') as f:
+        #             file_contents = f.read()
+        #     except Exception:
+        #         log.exception("Unable to read file %s", filepath)
+        #         file_contents = None
+        #
+        #     if file_contents and is_java_file(filepath):
+        #         try:
+        #             ast = javalang.parse.parse(file_contents)
+        #         except (javalang.parser.JavaSyntaxError, IndexError):
+        #             log.debug("Unable to parse AST for file %s", filepath)
+        #
+        #     for plugin in plugins:
+        #         log.debug("Running plugin %s", plugin.name)
+        #         plugin.run(filepath,
+        #                    apk_constants=self.apk_constants,
+        #                    java_ast=ast,
+        #                    file_contents=file_contents,
+        #                    all_files=self.files)
+        #
+        # for plugin in plugins:
+        #     self.issues.extend(plugin.issues)
 
     def _gather_files(self):
         """Walks the `Decompiler.build_directory` and updates the `self.files` set with new files."""
-        if path.splitext(self.path_to_source.lower())[1] == ".java":
+        if is_java_file(self.path_to_source):
             self.files.add(self.path_to_source)
             return
 
@@ -119,6 +115,29 @@ class Scanner(object):
         except AttributeError:
             log.debug("Decompiler does not have a build directory")
 
-        # Set the manifest path if it doesn't exist (we are walking a Java source code directory)
-        if not self.manifest_path:
-            self.manifest_path = get_manifest_out_of_files(self.files)
+
+class Subject(object):
+    """"""
+
+    def __init__(self):
+        self.observers = []
+
+    def register(self, observer):
+        """
+        :param PluginObserver observer:
+        """
+        self.observers.append(observer)
+
+    def unregister(self, observer):
+        """
+        :param PluginObserver observer:
+        """
+        self.observers.remove(observer)
+
+    def notify(self, file_path):
+        for observer in self.observers:
+            observer.update(file_path, call_run=True)
+
+    def reset(self):
+        for observer in self.observers:
+            observer.reset()

--- a/qark/scanner/scanner.py
+++ b/qark/scanner/scanner.py
@@ -7,7 +7,7 @@ from os import (
 )
 
 import javalang
-from qark.plugins.manifest_helpers import get_min_sdk, get_target_sdk
+from qark.plugins.manifest_helpers import get_min_sdk, get_target_sdk, get_package_from_manifest
 from qark.scanner.plugin import get_plugin_source, get_plugins
 from qark.scanner.plugin import ManifestPlugin
 from qark.xml_helpers import get_manifest_out_of_files
@@ -37,22 +37,7 @@ class Scanner(object):
         self.path_to_source = path_to_source
         self.build_directory = build_directory
 
-    def run(self):
-        """
-        Runs all the plugin checks by category.
-        """
         self._gather_files()
-
-        plugins = []
-        for category in PLUGIN_CATEGORIES:
-            plugin_source = get_plugin_source(category=category)
-
-            for plugin_name in get_plugins(category):
-                plugins.append(plugin_source.load_plugin(plugin_name).plugin)
-
-        self._run_checks(plugins)
-
-    def _run_checks(self, plugins):
         try:
             min_sdk = get_min_sdk(self.manifest_path, files=self.files)
             target_sdk = get_target_sdk(self.manifest_path, files=self.files)
@@ -60,6 +45,40 @@ class Scanner(object):
             # manifest path is not set, assume min_sdk and target_sdk
             min_sdk = target_sdk = 1
 
+        try:
+            package_name = get_package_from_manifest(self.manifest_path)
+        except IOError:
+            package_name = "PACKAGE_NOT_FOUND"
+
+        self.apk_constants = {"min_sdk": min_sdk,
+                              "target_sdk": target_sdk,
+                              "package_name": package_name}
+
+    def run(self):
+        """
+        Runs all the plugin checks by category.
+        """
+        plugins = []
+        for category in PLUGIN_CATEGORIES:
+            plugin_source = get_plugin_source(category=category)
+
+            if category == "manifest":
+                # Manifest plugins only need to run once, so we run them and continue
+                manifest_plugins = get_plugins(category)
+
+                for plugin in (plugin_source.load_plugin(plugin_name).plugin for plugin_name in manifest_plugins):
+                    plugin.run(all_files=self.files,
+                               apk_constants=self.apk_constants)
+                    self.issues.extend(plugin.issues)
+                continue
+
+            for plugin_name in get_plugins(category):
+                plugins.append(plugin_source.load_plugin(plugin_name).plugin)
+
+        self._run_checks(plugins)
+
+    def _run_checks(self, plugins):
+        """Run all the plugins (besides manifest) on every file."""
         for filepath in self.files:
             ast = None
 
@@ -77,20 +96,18 @@ class Scanner(object):
                     log.debug("Unable to parse AST for file %s", filepath)
 
             for plugin in plugins:
-                log.debug("Running plugin %s", plugin)
-                plugin.run(filepath, apk_constants={"min_sdk": min_sdk,
-                                                    "target_sdk": target_sdk},
+                log.debug("Running plugin %s", plugin.name)
+                plugin.run(filepath,
+                           apk_constants=self.apk_constants,
                            java_ast=ast,
                            file_contents=file_contents,
                            all_files=self.files)
 
-                self.issues.extend(plugin.issues)
+        for plugin in plugins:
+            self.issues.extend(plugin.issues)
 
     def _gather_files(self):
-        """
-        Walks the `Decompiler.build_directory` and updates the `self.files` set with new files.
-        :return:
-        """
+        """Walks the `Decompiler.build_directory` and updates the `self.files` set with new files."""
         if path.splitext(self.path_to_source.lower())[1] == ".java":
             self.files.add(self.path_to_source)
             return

--- a/qark/utils.py
+++ b/qark/utils.py
@@ -1,4 +1,5 @@
 import os
+from functools import partial
 
 
 def create_directories_to_path(path):
@@ -9,3 +10,10 @@ def create_directories_to_path(path):
     except Exception:
         # directory already exists
         pass
+
+
+def file_has_extension(extension, file_path):
+    return os.path.splitext(file_path.lower())[1] == extension.lower()
+
+
+is_java_file = partial(file_has_extension, ".java")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import os
 
 from qark.decompiler.decompiler import Decompiler
 from qark.scanner.scanner import Scanner
+from qark.scanner.plugin import JavaASTPlugin, ManifestPlugin
 
 
 @pytest.fixture(scope="session")
@@ -58,6 +59,12 @@ def vulnerable_manifest_path():
 
 
 @pytest.fixture(scope="session")
+def goatdroid_manifest_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_xml_files",
+                        "test_goatdroid_manifest.xml")
+
+
+@pytest.fixture(scope="session")
 def test_java_files():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_java_files")
 
@@ -72,3 +79,15 @@ def vulnerable_broadcast_path(test_java_files):
 def vulnerable_receiver_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_plugins", "test_manifest_plugins",
                         "broadcastreceivers", "SendSMSNowReceiver.java")
+
+
+@pytest.fixture(autouse=True)
+def reset_plugins():
+    """Reset all plugins in between each function. `JavaASTPlugin` currently will reset every other plugin type."""
+    JavaASTPlugin.reset()
+
+    ManifestPlugin.manifest_xml = None
+    ManifestPlugin.manifest_path = None
+    ManifestPlugin.min_sdk = -1
+    ManifestPlugin.target_sdk = -1
+    ManifestPlugin.package_name = "PACKAGE_NOT_FOUND"

--- a/tests/test_plugins/test_broadcast_plugins/test_dynamic_broadcast_receiver.py
+++ b/tests/test_plugins/test_broadcast_plugins/test_dynamic_broadcast_receiver.py
@@ -1,12 +1,19 @@
 import os
 
+import javalang
+
 from qark.plugins.broadcast.dynamic_broadcast_receiver import DynamicBroadcastReceiver
 
 
 def test_vulnerable_dynamic_broadcast_receiver(test_java_files):
     plugin = DynamicBroadcastReceiver()
-    plugin.run(files=[os.path.join(test_java_files,
-                                   "dynamic_broadcast_receiver.java")],
+    path_to_vuln_file = os.path.join(test_java_files,
+                                     "dynamic_broadcast_receiver.java")
+    with open(path_to_vuln_file) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path_to_vuln_file,
+               java_ast=ast,
                apk_constants={"min_sdk": 5})
 
     assert len(plugin.issues) == 1  # vulnerable manifest
@@ -17,8 +24,13 @@ def test_vulnerable_dynamic_broadcast_receiver(test_java_files):
 
 def test_nonvulnerable_dynamic_broadcast_receiver(test_java_files):
     plugin = DynamicBroadcastReceiver()
-    plugin.run(files=[os.path.join(test_java_files,
-                                   "dynamic_broadcast_receiver.java")],
+    path_to_vuln_file = os.path.join(test_java_files,
+                                     "dynamic_broadcast_receiver.java")
+    with open(path_to_vuln_file) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path_to_vuln_file,
+               java_ast=ast,
                apk_constants={"min_sdk": 14})
 
     assert len(plugin.issues) == 0

--- a/tests/test_plugins/test_broadcast_plugins/test_dynamic_broadcast_receiver.py
+++ b/tests/test_plugins/test_broadcast_plugins/test_dynamic_broadcast_receiver.py
@@ -3,18 +3,17 @@ import os
 import javalang
 
 from qark.plugins.broadcast.dynamic_broadcast_receiver import DynamicBroadcastReceiver
+from qark.scanner.plugin import ManifestPlugin
 
 
 def test_vulnerable_dynamic_broadcast_receiver(test_java_files):
     plugin = DynamicBroadcastReceiver()
     path_to_vuln_file = os.path.join(test_java_files,
                                      "dynamic_broadcast_receiver.java")
-    with open(path_to_vuln_file) as f:
-        ast = javalang.parse.parse(f.read())
 
-    plugin.run(path_to_vuln_file,
-               java_ast=ast,
-               apk_constants={"min_sdk": 5})
+    ManifestPlugin.min_sdk = 5
+    plugin.update(file_path=path_to_vuln_file)
+    plugin.run()
 
     assert len(plugin.issues) == 1  # vulnerable manifest
     assert plugin.issues[0].name == plugin.name
@@ -26,12 +25,9 @@ def test_nonvulnerable_dynamic_broadcast_receiver(test_java_files):
     plugin = DynamicBroadcastReceiver()
     path_to_vuln_file = os.path.join(test_java_files,
                                      "dynamic_broadcast_receiver.java")
-    with open(path_to_vuln_file) as f:
-        ast = javalang.parse.parse(f.read())
-
-    plugin.run(path_to_vuln_file,
-               java_ast=ast,
-               apk_constants={"min_sdk": 14})
+    plugin.update(file_path=path_to_vuln_file)
+    ManifestPlugin.min_sdk = 14
+    plugin.run()
 
     assert len(plugin.issues) == 0
 

--- a/tests/test_plugins/test_broadcast_plugins/test_send_broadcast_receiver_permission.py
+++ b/tests/test_plugins/test_broadcast_plugins/test_send_broadcast_receiver_permission.py
@@ -1,7 +1,17 @@
 from qark.plugins.broadcast.send_broadcast_receiver_permission import SendBroadcastReceiverPermission
 
+import javalang
+
 
 def test_send_broadcast_receiver_permission(vulnerable_broadcast_path):
+    with open(vulnerable_broadcast_path) as f:
+        contents = f.read()
+
+    ast = javalang.parse.parse(contents)
+
     plugin = SendBroadcastReceiverPermission()
-    plugin.run([vulnerable_broadcast_path])
-    assert len(plugin.issues) == 8
+    plugin.run(vulnerable_broadcast_path,
+               java_ast=ast,
+               file_contents=contents,
+               apk_constants={"min_sdk": 25})
+    assert 8 == len(plugin.issues)

--- a/tests/test_plugins/test_broadcast_plugins/test_send_broadcast_receiver_permission.py
+++ b/tests/test_plugins/test_broadcast_plugins/test_send_broadcast_receiver_permission.py
@@ -1,17 +1,10 @@
 from qark.plugins.broadcast.send_broadcast_receiver_permission import SendBroadcastReceiverPermission
-
-import javalang
+from qark.scanner.plugin import ManifestPlugin
 
 
 def test_send_broadcast_receiver_permission(vulnerable_broadcast_path):
-    with open(vulnerable_broadcast_path) as f:
-        contents = f.read()
-
-    ast = javalang.parse.parse(contents)
-
+    ManifestPlugin.min_sdk = 25
     plugin = SendBroadcastReceiverPermission()
-    plugin.run(vulnerable_broadcast_path,
-               java_ast=ast,
-               file_contents=contents,
-               apk_constants={"min_sdk": 25})
+    plugin.update(file_path=vulnerable_broadcast_path)
+    plugin.run()
     assert 8 == len(plugin.issues)

--- a/tests/test_plugins/test_cert_plugins/test_cert_plugins.py
+++ b/tests/test_plugins/test_cert_plugins/test_cert_plugins.py
@@ -1,6 +1,7 @@
 from qark.plugins.cert.cert_validation_methods_overriden import CertValidation
 from qark.plugins.cert.hostname_verifier import HostnameVerifier, ALLOW_ALL_HOSTNAME_VERIFIER_DESC
 
+import javalang
 
 from qark.issue import Severity
 
@@ -9,13 +10,21 @@ import os
 
 def test_cert_validation_methods():
     plugin = CertValidation()
-    plugin.run([os.path.join(os.path.dirname(os.path.abspath(__file__)), "testCertMethodsFile.java")])
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "testCertMethodsFile.java")
+    with open(path) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path, java_ast=ast)
     assert 3 == len(plugin.issues)
 
 
 def test_hostname_verifier():
     plugin = HostnameVerifier()
-    plugin.run([os.path.join(os.path.dirname(os.path.abspath(__file__)), "testHostnameVerifier.java")])
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "testHostnameVerifier.java")
+    with open(path) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path, java_ast=ast)
     assert 2 == len(plugin.issues)
     assert "Allow all hostname verifier used" == plugin.issues[0].name
     assert "setHostnameVerifier set to ALLOW_ALL" == plugin.issues[1].name

--- a/tests/test_plugins/test_cert_plugins/test_cert_plugins.py
+++ b/tests/test_plugins/test_cert_plugins/test_cert_plugins.py
@@ -9,22 +9,18 @@ import os
 
 
 def test_cert_validation_methods():
-    plugin = CertValidation()
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "testCertMethodsFile.java")
-    with open(path) as f:
-        ast = javalang.parse.parse(f.read())
 
-    plugin.run(path, java_ast=ast)
+    plugin = CertValidation()
+    plugin.update(path, call_run=True)
     assert 3 == len(plugin.issues)
 
 
 def test_hostname_verifier():
     plugin = HostnameVerifier()
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "testHostnameVerifier.java")
-    with open(path) as f:
-        ast = javalang.parse.parse(f.read())
 
-    plugin.run(path, java_ast=ast)
+    plugin.update(path, call_run=True)
     assert 2 == len(plugin.issues)
     assert "Allow all hostname verifier used" == plugin.issues[0].name
     assert "setHostnameVerifier set to ALLOW_ALL" == plugin.issues[1].name

--- a/tests/test_plugins/test_crypto_plugins/java_files/secure_random_args2.java
+++ b/tests/test_plugins/test_crypto_plugins/java_files/secure_random_args2.java
@@ -1,5 +1,5 @@
 import java.security.SecureRandom;
-import java.math.BigInteger
+import java.math.BigInteger;
 
 class Aoeu{
 	public BigInteger generate(){
@@ -9,5 +9,5 @@ class Aoeu{
 		random.setSeed(seed);
 		return new BigInteger(130, random).toString(32);
 	}
-	 
+
 }

--- a/tests/test_plugins/test_crypto_plugins/test_crypto_plugins.py
+++ b/tests/test_plugins/test_crypto_plugins/test_crypto_plugins.py
@@ -4,6 +4,8 @@ from qark.plugins.crypto.ecb_cipher_usage import ECBCipherCheck
 from qark.plugins.crypto.packaged_private_keys import PackagedPrivateKeys
 from qark.plugins.crypto.setting_secure_random_seed import SeedWithSecureRandom
 
+import javalang
+
 curr_dir = os.path.dirname(__file__)
 java_dir = os.path.join(curr_dir, 'java_files')
 
@@ -14,37 +16,57 @@ def test_blank_file():
     plugins = (SeedWithSecureRandom(), ECBCipherCheck(), PackagedPrivateKeys())
     for plugin in plugins:
         for file in files:
-            plugin.run(file)
+            with open(file) as f:
+                contents = f.read()
+                try:
+                    ast = javalang.parse.parse(contents)
+                except javalang.parser.JavaSyntaxError:
+                    ast = None
+
+            plugin.run(file, java_ast=ast, file_contents=contents)
         assert plugin.issues == []
 
 
 def test_seeding_secure_random():
     no_bug_files = ['secure_random_no_args1.java']
-    buggy_files = ['secure_random_args1.java', 'secure_random_args1.java']
+    buggy_files = ['secure_random_args1.java', 'secure_random_args2.java']
     plugin = SeedWithSecureRandom()
     for curr_file in no_bug_files:
         curr_file = os.path.join(java_dir, curr_file)
-        plugin.run([curr_file])
+
+        with open(curr_file) as f:
+            ast = javalang.parse.parse(f.read())
+
+        plugin.run(curr_file, java_ast=ast)
         assert not plugin.issues
+
     for i, curr_file in enumerate(buggy_files):
         curr_file = os.path.join(java_dir, curr_file)
-        assert len(plugin.issues) == i
-        plugin.run([curr_file])
-        assert len(plugin.issues) == i + 1
+
+        with open(curr_file) as f:
+            ast = javalang.parse.parse(f.read())
+
+        assert i == len(plugin.issues)
+        plugin.run(curr_file, java_ast=ast)
+        assert i + 1 == len(plugin.issues)
 
 
 def test_packaged_private_keys():
     key_dir = os.path.join(curr_dir, 'keys')
     plugin = PackagedPrivateKeys()
-    assert len(plugin.issues) == 0
+    assert 0 == len(plugin.issues)
     private_key_files = ['rsa-key', 'dsa-key', 'ed25519-key', 'ecdsa-key']
     for i, file_path in enumerate(private_key_files):
         absolute_path = os.path.join(key_dir, file_path)
-        assert len(plugin.issues) == i
-        plugin.run([absolute_path])
-        assert len(plugin.issues) == i + 1
+        assert i == len(plugin.issues)
+        with open(absolute_path) as f:
+            contents = f.read()
+        plugin.run(absolute_path, file_contents=contents)
+        assert i + 1 == len(plugin.issues)
     public_key_files = [path + '.pub' for path in private_key_files]
     num_issues = len(plugin.issues)
     for file_path in public_key_files:
-        plugin.run([file_path])
-        assert len(plugin.issues) == num_issues
+        with open(os.path.join(key_dir, file_path)) as f:
+            contents = f.read()
+        plugin.run(file_path, file_contents=contents)
+        assert num_issues == len(plugin.issues)

--- a/tests/test_plugins/test_crypto_plugins/test_crypto_plugins.py
+++ b/tests/test_plugins/test_crypto_plugins/test_crypto_plugins.py
@@ -12,18 +12,11 @@ java_dir = os.path.join(curr_dir, 'java_files')
 
 def test_blank_file():
     files = ('invalid.java', 'blank.java')
-    files = tuple([os.path.join(java_dir, file) for file in files])
+    files = tuple(os.path.join(java_dir, file) for file in files)
     plugins = (SeedWithSecureRandom(), ECBCipherCheck(), PackagedPrivateKeys())
     for plugin in plugins:
         for file in files:
-            with open(file) as f:
-                contents = f.read()
-                try:
-                    ast = javalang.parse.parse(contents)
-                except javalang.parser.JavaSyntaxError:
-                    ast = None
-
-            plugin.run(file, java_ast=ast, file_contents=contents)
+            plugin.update(file_path=file, call_run=True)
         assert plugin.issues == []
 
 
@@ -34,20 +27,18 @@ def test_seeding_secure_random():
     for curr_file in no_bug_files:
         curr_file = os.path.join(java_dir, curr_file)
 
-        with open(curr_file) as f:
-            ast = javalang.parse.parse(f.read())
+        plugin.update(file_path=curr_file, call_run=True)
 
-        plugin.run(curr_file, java_ast=ast)
+        plugin.run()
         assert not plugin.issues
+
+    plugin.reset()
 
     for i, curr_file in enumerate(buggy_files):
         curr_file = os.path.join(java_dir, curr_file)
 
-        with open(curr_file) as f:
-            ast = javalang.parse.parse(f.read())
-
         assert i == len(plugin.issues)
-        plugin.run(curr_file, java_ast=ast)
+        plugin.update(file_path=curr_file, call_run=True)
         assert i + 1 == len(plugin.issues)
 
 
@@ -55,18 +46,18 @@ def test_packaged_private_keys():
     key_dir = os.path.join(curr_dir, 'keys')
     plugin = PackagedPrivateKeys()
     assert 0 == len(plugin.issues)
+
     private_key_files = ['rsa-key', 'dsa-key', 'ed25519-key', 'ecdsa-key']
     for i, file_path in enumerate(private_key_files):
         absolute_path = os.path.join(key_dir, file_path)
         assert i == len(plugin.issues)
-        with open(absolute_path) as f:
-            contents = f.read()
-        plugin.run(absolute_path, file_contents=contents)
+        plugin.reset()
+        plugin.update(file_path=absolute_path, call_run=True)
         assert i + 1 == len(plugin.issues)
+
     public_key_files = [path + '.pub' for path in private_key_files]
     num_issues = len(plugin.issues)
     for file_path in public_key_files:
-        with open(os.path.join(key_dir, file_path)) as f:
-            contents = f.read()
-        plugin.run(file_path, file_contents=contents)
+        plugin.reset()
+        plugin.update(file_path=os.path.join(key_dir, file_path), call_run=True)
         assert num_issues == len(plugin.issues)

--- a/tests/test_plugins/test_crypto_plugins/test_ecb.py
+++ b/tests/test_plugins/test_crypto_plugins/test_ecb.py
@@ -11,22 +11,20 @@ java_dir = os.path.join(curr_dir, 'java_files')
 def test_ecb_cipher_usage():
     plugin = ECBCipherCheck()
     files_with_ecb = ['ecb1.java', 'ecb2.java']
-    files_without_ecb = ['blank.java', 'no_ecb1.java']
+    files_without_ecb = ['no_ecb1.java']
 
     for file in files_without_ecb:
         file = os.path.join(java_dir, file)
-        with open(file) as f:
-            ast = javalang.parse.parse(f.read())
+        plugin.update(file_path=file)
+        plugin.run()
 
-        plugin.run(file, java_ast=ast)
     assert not plugin.issues
+
+    plugin.reset()
 
     for i, file in enumerate(files_with_ecb):
         file = os.path.join(java_dir, file)
-
-        with open(file) as f:
-            ast = javalang.parse.parse(f.read())
-
+        plugin.update(file_path=file)
         assert len(plugin.issues) == i
-        plugin.run(file, java_ast=ast)
+        plugin.run()
         assert len(plugin.issues) == i + 1

--- a/tests/test_plugins/test_crypto_plugins/test_ecb.py
+++ b/tests/test_plugins/test_crypto_plugins/test_ecb.py
@@ -1,19 +1,11 @@
 import os
 
+import javalang
+
 from qark.plugins.crypto.ecb_cipher_usage import ECBCipherCheck
 
 curr_dir = os.path.dirname(__file__)
 java_dir = os.path.join(curr_dir, 'java_files')
-
-
-def test_non_existent_file():
-    """The scan should not throw exceptions on a non-existent file"""
-    plugin = ECBCipherCheck()
-    non_existent_files = ['----']
-    try:
-        plugin.run(non_existent_files)
-    except Exception:
-        assert False
 
 
 def test_ecb_cipher_usage():
@@ -23,10 +15,18 @@ def test_ecb_cipher_usage():
 
     for file in files_without_ecb:
         file = os.path.join(java_dir, file)
-        plugin.run([file])
+        with open(file) as f:
+            ast = javalang.parse.parse(f.read())
+
+        plugin.run(file, java_ast=ast)
     assert not plugin.issues
+
     for i, file in enumerate(files_with_ecb):
         file = os.path.join(java_dir, file)
+
+        with open(file) as f:
+            ast = javalang.parse.parse(f.read())
+
         assert len(plugin.issues) == i
-        plugin.run([file])
+        plugin.run(file, java_ast=ast)
         assert len(plugin.issues) == i + 1

--- a/tests/test_plugins/test_file_plugins/test_file_plugins.py
+++ b/tests/test_plugins/test_file_plugins/test_file_plugins.py
@@ -7,14 +7,19 @@ from qark.plugins.file.external_storage import ExternalStorage
 from qark.plugins.file.api_keys import JavaAPIKeys
 from qark.issue import Severity
 
+import javalang
+
 import os
 import tempfile
 
 
 def test_file_permissions():
     plugin = FilePermissions()
-    plugin.run([os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_file_permissions.java")],
-               apk_constants={})
+    path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_file_permissions.java")
+    with open(path) as f:
+        contents = f.read()
+
+    plugin.run(path, file_contents=contents, apk_constants={})
     assert len(plugin.issues) == 2
     assert "World readable file" == plugin.issues[0].name
     assert Severity.WARNING == plugin.issues[0].severity
@@ -26,52 +31,68 @@ def test_file_permissions():
 
 def test_phone_identifier(test_java_files):
     plugin = PhoneIdentifier()
-    plugin.run([os.path.join(test_java_files,
-                             "phone_identifier.java")])
+    path = os.path.join(test_java_files,
+                        "phone_identifier.java")
+    with open(path) as f:
+        contents = f.read()
+
+    plugin.run(path, file_contents=contents)
     assert 1 == len(plugin.issues)
-    
-    
+
+
 def test_insecure_functions(test_java_files):
     plugin = InsecureFunctions()
-    plugin.run([os.path.join(test_java_files,
-                             "insecure_functions.java")])
+    path = os.path.join(test_java_files,
+                        "insecure_functions.java")
+    with open(path) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path, java_ast=ast)
     assert 1 == len(plugin.issues)
-    
-    
+
+
 def test_http_url_hardcoded(test_java_files):
     plugin = HardcodedHTTP()
-    plugin.run([os.path.join(test_java_files,
-                             "http_url_hardcoded.java")])
+    path = os.path.join(test_java_files,
+                        "http_url_hardcoded.java")
+    with open(path) as f:
+        contents = f.read()
+
+    plugin.run(path, file_contents=contents)
 
     assert 1 == len(plugin.issues)
 
 
 def test_android_logging(test_java_files):
     plugin = AndroidLogging()
-    plugin.run([os.path.join(test_java_files,
-                             "test_android_logging.java")])
+    path = os.path.join(test_java_files,
+                        "test_android_logging.java")
+    with open(path) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path, java_ast=ast)
     assert 2 == len(plugin.issues)
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
     assert plugin.issues[0].category == plugin.category
-    
-    
+
+
 def test_external_storage(test_java_files):
     plugin = ExternalStorage()
-    plugin.run([os.path.join(test_java_files,
-                             "external_storage.java")])
+    path = os.path.join(test_java_files,
+                        "external_storage.java")
+    with open(path) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(path, java_ast=ast)
     assert 4 == len(plugin.issues)
 
-    
+
 def test_api_keys():
     plugin = JavaAPIKeys()
-    with tempfile.NamedTemporaryFile(mode="w", prefix="vuln1", suffix=".java") as vulnerable_file:
-        with tempfile.NamedTemporaryFile(mode="w", prefix="vuln2", suffix=".java") as nonvulnerable_file:
-            nonvulnerable_file.write("""public static final String API_TOKEN = "1234thisisaninvalidapitoken937235""")
-            vulnerable_file.write("""public static final String API_TOKEN = "Nti4kWY-qRHTYq3dsbeip0P1tbGCzs2BAY163ManCAb""")
-            nonvulnerable_file.seek(0)
-            vulnerable_file.seek(0)
-
-            plugin.run([nonvulnerable_file.name,
-                        vulnerable_file.name])
-            assert 1 == len(plugin.issues)
+    plugin.run("path",
+               file_contents="""public static final String API_TOKEN = "1234thisisaninvalidapitoken937235""")
+    assert 0 == len(plugin.issues)
+    plugin.run("path",
+               file_contents="""public static final String API_TOKEN = "Nti4kWY-qRHTYq3dsbeip0P1tbGCzs2BAY163ManCAb""")
+    assert 1 == len(plugin.issues)

--- a/tests/test_plugins/test_file_plugins/test_file_plugins.py
+++ b/tests/test_plugins/test_file_plugins/test_file_plugins.py
@@ -10,16 +10,14 @@ from qark.issue import Severity
 import javalang
 
 import os
-import tempfile
 
 
 def test_file_permissions():
     plugin = FilePermissions()
     path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_file_permissions.java")
-    with open(path) as f:
-        contents = f.read()
+    plugin.update(file_path=path)
 
-    plugin.run(path, file_contents=contents, apk_constants={})
+    plugin.run()
     assert len(plugin.issues) == 2
     assert "World readable file" == plugin.issues[0].name
     assert Severity.WARNING == plugin.issues[0].severity
@@ -33,10 +31,8 @@ def test_phone_identifier(test_java_files):
     plugin = PhoneIdentifier()
     path = os.path.join(test_java_files,
                         "phone_identifier.java")
-    with open(path) as f:
-        contents = f.read()
-
-    plugin.run(path, file_contents=contents)
+    plugin.update(file_path=path)
+    plugin.run()
     assert 1 == len(plugin.issues)
 
 
@@ -44,10 +40,9 @@ def test_insecure_functions(test_java_files):
     plugin = InsecureFunctions()
     path = os.path.join(test_java_files,
                         "insecure_functions.java")
-    with open(path) as f:
-        ast = javalang.parse.parse(f.read())
 
-    plugin.run(path, java_ast=ast)
+    plugin.update(file_path=path)
+    plugin.run()
     assert 1 == len(plugin.issues)
 
 
@@ -55,10 +50,8 @@ def test_http_url_hardcoded(test_java_files):
     plugin = HardcodedHTTP()
     path = os.path.join(test_java_files,
                         "http_url_hardcoded.java")
-    with open(path) as f:
-        contents = f.read()
-
-    plugin.run(path, file_contents=contents)
+    plugin.update(file_path=path)
+    plugin.run()
 
     assert 1 == len(plugin.issues)
 
@@ -67,10 +60,8 @@ def test_android_logging(test_java_files):
     plugin = AndroidLogging()
     path = os.path.join(test_java_files,
                         "test_android_logging.java")
-    with open(path) as f:
-        ast = javalang.parse.parse(f.read())
-
-    plugin.run(path, java_ast=ast)
+    plugin.update(file_path=path)
+    plugin.run()
     assert 2 == len(plugin.issues)
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
@@ -81,18 +72,20 @@ def test_external_storage(test_java_files):
     plugin = ExternalStorage()
     path = os.path.join(test_java_files,
                         "external_storage.java")
-    with open(path) as f:
-        ast = javalang.parse.parse(f.read())
+    plugin.update(file_path=path)
 
-    plugin.run(path, java_ast=ast)
+    plugin.run()
     assert 4 == len(plugin.issues)
 
 
 def test_api_keys():
     plugin = JavaAPIKeys()
-    plugin.run("path",
-               file_contents="""public static final String API_TOKEN = "1234thisisaninvalidapitoken937235""")
+    JavaAPIKeys.file_contents = """public static final String API_TOKEN = "1234thisisaninvalidapitoken937235"""
+    JavaAPIKeys.file_path = "path"
+    plugin.run()
     assert 0 == len(plugin.issues)
-    plugin.run("path",
-               file_contents="""public static final String API_TOKEN = "Nti4kWY-qRHTYq3dsbeip0P1tbGCzs2BAY163ManCAb""")
+    plugin.reset()
+    JavaAPIKeys.file_contents = """public static final String API_TOKEN = "Nti4kWY-qRHTYq3dsbeip0P1tbGCzs2BAY163ManCAb"""
+    JavaAPIKeys.file_path = "path"
+    plugin.run()
     assert 1 == len(plugin.issues)

--- a/tests/test_plugins/test_generic_plugins/test_check_permissions.py
+++ b/tests/test_plugins/test_generic_plugins/test_check_permissions.py
@@ -1,16 +1,12 @@
 from qark.plugins.generic.check_permissions import CheckPermissions
 
 import os
-import javalang
 
 
 def test_check_permissions(test_java_files):
     plugin = CheckPermissions()
     path = os.path.join(test_java_files,
                         "check_permissions.java")
-    with open(path) as f:
-        contents = f.read()
-
-    ast = javalang.parse.parse(contents)
-    plugin.run(path, file_contents=contents, java_ast=ast)
+    plugin.update(file_path=path)
+    plugin.run()
     assert 2 == len(plugin.issues)

--- a/tests/test_plugins/test_generic_plugins/test_check_permissions.py
+++ b/tests/test_plugins/test_generic_plugins/test_check_permissions.py
@@ -1,10 +1,16 @@
 from qark.plugins.generic.check_permissions import CheckPermissions
 
 import os
+import javalang
 
 
 def test_check_permissions(test_java_files):
     plugin = CheckPermissions()
-    plugin.run([os.path.join(test_java_files,
-                             "check_permissions.java")])
+    path = os.path.join(test_java_files,
+                        "check_permissions.java")
+    with open(path) as f:
+        contents = f.read()
+
+    ast = javalang.parse.parse(contents)
+    plugin.run(path, file_contents=contents, java_ast=ast)
     assert 2 == len(plugin.issues)

--- a/tests/test_plugins/test_intent/test_intent_plugins.py
+++ b/tests/test_plugins/test_intent/test_intent_plugins.py
@@ -3,6 +3,8 @@ import shutil
 
 from qark.plugins.intent.implicit_intent_to_pending_intent import ImplicitIntentToPendingIntent
 
+import javalang
+
 vuln_java_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_implicit_intent.java")
 
 
@@ -12,7 +14,11 @@ def test_empty_intent(build_directory):
         shutil.rmtree(build_directory)
 
     plugin = ImplicitIntentToPendingIntent()
-    plugin.run([vuln_java_file])
+    with open(vuln_java_file) as f:
+        contents = f.read()
+
+    ast = javalang.parse.parse(contents)
+    plugin.run(vuln_java_file, file_contents=contents, java_ast=ast)
     assert len(plugin.issues) == 4
     if os.path.isdir(build_directory):
         shutil.rmtree(build_directory)

--- a/tests/test_plugins/test_intent/test_intent_plugins.py
+++ b/tests/test_plugins/test_intent/test_intent_plugins.py
@@ -1,24 +1,13 @@
 import os
-import shutil
 
 from qark.plugins.intent.implicit_intent_to_pending_intent import ImplicitIntentToPendingIntent
 
-import javalang
 
 vuln_java_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_implicit_intent.java")
 
 
-def test_empty_intent(build_directory):
-    # set the path to manifest file
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)
-
+def test_empty_intent():
     plugin = ImplicitIntentToPendingIntent()
-    with open(vuln_java_file) as f:
-        contents = f.read()
-
-    ast = javalang.parse.parse(contents)
-    plugin.run(vuln_java_file, file_contents=contents, java_ast=ast)
+    plugin.update(file_path=vuln_java_file)
+    plugin.run()
     assert len(plugin.issues) == 4
-    if os.path.isdir(build_directory):
-        shutil.rmtree(build_directory)

--- a/tests/test_plugins/test_manifest_plugins/test_manifest_plugins.py
+++ b/tests/test_plugins/test_manifest_plugins/test_manifest_plugins.py
@@ -32,7 +32,7 @@ def goatdroid_manifest(module_decompiler, build_directory):
 
 def test_vulnerable_allow_backup(test_android_manifest):
     plugin = ManifestBackupAllowed(manifest_xml=test_android_manifest)
-    plugin.run([], apk_constants={})
+    plugin.run(apk_constants={})
     assert len(plugin.issues) == 1
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
@@ -41,13 +41,13 @@ def test_vulnerable_allow_backup(test_android_manifest):
 
 def test_nonvulnerable_allow_backup(goatdroid_manifest):
     plugin = ManifestBackupAllowed(manifest_xml=goatdroid_manifest)
-    plugin.run([], apk_constants={})
+    plugin.run(apk_constants={})
     assert len(plugin.issues) == 0  # non vulnerable manifest
 
 
 def test_custom_permission_vulnerable(test_android_manifest):
     plugin = CustomPermissions(manifest_xml=test_android_manifest)
-    plugin.run([], apk_constants={})
+    plugin.run(apk_constants={})
     assert len(plugin.issues) == 2
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity
@@ -56,19 +56,19 @@ def test_custom_permission_vulnerable(test_android_manifest):
 
 def test_custom_permission_nonvulnerable(goatdroid_manifest):
     plugin = CustomPermissions(manifest_xml=goatdroid_manifest)
-    plugin.run([], apk_constants={})
+    plugin.run(apk_constants={})
     assert len(plugin.issues) == 0
 
 
 def test_debuggable_nonvulnerable(test_android_manifest):
     plugin = DebuggableManifest(manifest_xml=test_android_manifest)
-    plugin.run([], apk_constants={})
+    plugin.run(apk_constants={})
     assert len(plugin.issues) == 0
 
 
 def test_debuggable_vulnerable(goatdroid_manifest):
     plugin = DebuggableManifest(manifest_xml=goatdroid_manifest)
-    plugin.run([], apk_constants={})
+    plugin.run(apk_constants={})
     assert len(plugin.issues) == 1  # vulnerable manifest
     assert plugin.issues[0].name == plugin.name
     assert plugin.issues[0].severity == plugin.severity
@@ -78,7 +78,7 @@ def test_debuggable_vulnerable(goatdroid_manifest):
 def test_vulnerable_exported_tags(vulnerable_manifest_path, vulnerable_receiver_path):
     ManifestPlugin.update_manifest(vulnerable_manifest_path)
     plugin = ExportedTags()
-    plugin.run([vulnerable_receiver_path], apk_constants={})
+    plugin.run(all_files=[vulnerable_receiver_path], apk_constants={})
     assert len(plugin.issues) == 6
     for issue in plugin.issues:
         assert Severity.WARNING == issue.severity
@@ -95,7 +95,7 @@ def test_vulnerable_min_sdk(apk_constants):
                                                 "test_min_sdk_tapjacking",
                                                 "androidmanifest.xml"))
     plugin = MinSDK()
-    plugin.run([], apk_constants=apk_constants)
+    plugin.run(apk_constants=apk_constants)
     assert 1 == len(plugin.issues)
     for issue in plugin.issues:
         assert Severity.VULNERABILITY == issue.severity
@@ -107,26 +107,26 @@ def test_vulnerable_min_sdk(apk_constants):
 def test_android_path(vulnerable_manifest_path):
     ManifestPlugin.update_manifest(vulnerable_manifest_path)
     plugin = AndroidPath()
-    plugin.run([])
+    plugin.run()
     assert 1 == len(plugin.issues)
 
 
 def test_api_keys(vulnerable_manifest_path):
     ManifestPlugin.update_manifest(vulnerable_manifest_path)
     plugin = APIKeys()
-    plugin.run([])
+    plugin.run()
     assert 1 == len(plugin.issues)
 
 
 def test_single_task_launch_mode(vulnerable_manifest_path):
     ManifestPlugin.update_manifest(vulnerable_manifest_path)
     plugin = SingleTaskLaunchMode()
-    plugin.run([])
+    plugin.run()
     assert 1 == len(plugin.issues)
 
 
 def test_task_reparenting(vulnerable_manifest_path):
     ManifestPlugin.update_manifest(vulnerable_manifest_path)
     plugin = TaskReparenting()
-    plugin.run([])
+    plugin.run()
     assert 1 == len(plugin.issues)

--- a/tests/test_plugins/test_webviews/test_webviews.py
+++ b/tests/test_plugins/test_webviews/test_webviews.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import javalang
 
 from qark.issue import Severity
 from qark.plugins.webview.javascript_enabled import JavascriptEnabled, JAVASCRIPT_ENABLED_DESCRIPTION
@@ -30,7 +31,9 @@ VULNERABLE_DOM_STORAGE = os.path.join(os.path.dirname(os.path.abspath(__file__))
 
 def test_javascript_enabled():
     plugin = JavascriptEnabled()
-    plugin.run([VULNERABLE_WEBVIEW_PATH])
+    with open(VULNERABLE_WEBVIEW_PATH) as f:
+        ast = javalang.parse.parse(f.read())
+    plugin.run(VULNERABLE_WEBVIEW_PATH, java_ast=ast)
     assert 1 == len(plugin.issues)
     issue = plugin.issues[0]
     assert plugin.name == issue.name
@@ -41,7 +44,11 @@ def test_javascript_enabled():
 
 def test_load_data_with_base_url():
     plugin = LoadDataWithBaseURL()
-    plugin.run([VULNERABLE_WEBVIEW_PATH])
+
+    with open(VULNERABLE_WEBVIEW_PATH) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(VULNERABLE_WEBVIEW_PATH, java_ast=ast)
     assert 1 == len(plugin.issues)
     issue = plugin.issues[0]
     assert plugin.name == issue.name
@@ -52,7 +59,9 @@ def test_load_data_with_base_url():
 
 def test_set_allow_file_access():
     plugin = SetAllowFileAccess()
-    plugin.run([VULNERABLE_FILE_ACCESS])
+    with open(VULNERABLE_FILE_ACCESS) as f:
+        ast = javalang.parse.parse(f.read())
+    plugin.run(VULNERABLE_FILE_ACCESS, java_ast=ast)
     assert 2 == len(plugin.issues)
     for issue in plugin.issues:
         assert "webview" == issue.category
@@ -63,7 +72,10 @@ def test_set_allow_file_access():
 
 def test_set_allow_content_access():
     plugin = SetAllowContentAccess()
-    plugin.run([VULNERABLE_CONTENT_ACCESS])
+    with open(VULNERABLE_CONTENT_ACCESS) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(VULNERABLE_CONTENT_ACCESS, ast)
     assert 2 == len(plugin.issues)
     for issue in plugin.issues:
         assert "webview" == issue.category
@@ -73,7 +85,7 @@ def test_set_allow_content_access():
 
 
 @pytest.mark.parametrize("min_sdk, num_issues", [
-    (None, 2),
+    (None, 0),
     (1, 2),
     (14, 2),
     (15, 2),
@@ -82,7 +94,9 @@ def test_set_allow_content_access():
 ])
 def test_set_allow_universal_access_from_file_urls(min_sdk, num_issues):
     plugin = SetAllowUniversalAccessFromFileURLs()
-    plugin.run([VULNERABLE_UNIVERSAL_ACCESS], apk_constants={"min_sdk": min_sdk})
+    with open(VULNERABLE_UNIVERSAL_ACCESS) as f:
+        ast = javalang.parse.parse(f.read())
+    plugin.run(VULNERABLE_UNIVERSAL_ACCESS, java_ast=ast, apk_constants={"min_sdk": min_sdk})
     assert num_issues == len(plugin.issues)
     for issue in plugin.issues:
         assert "webview" == issue.category
@@ -92,7 +106,7 @@ def test_set_allow_universal_access_from_file_urls(min_sdk, num_issues):
 
 
 @pytest.mark.parametrize("min_sdk, num_issues", [
-    (None, 2),
+    (None, 0),
     (1, 2),
     (15, 2),
     (16, 2),
@@ -101,7 +115,10 @@ def test_set_allow_universal_access_from_file_urls(min_sdk, num_issues):
 ])
 def test_set_add_javascript_interface(min_sdk, num_issues):
     plugin = AddJavascriptInterface()
-    plugin.run([VULNERABLE_JAVASCRIPT_INTERFACE], apk_constants={"min_sdk": min_sdk})
+    with open(VULNERABLE_JAVASCRIPT_INTERFACE) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(VULNERABLE_JAVASCRIPT_INTERFACE, apk_constants={"min_sdk": min_sdk}, java_ast=ast)
     assert num_issues == len(plugin.issues)
     for issue in plugin.issues:
         assert "webview" == issue.category
@@ -112,7 +129,10 @@ def test_set_add_javascript_interface(min_sdk, num_issues):
 
 def test_set_dom_storage_enabled():
     plugin = SetDomStorageEnabled()
-    plugin.run([VULNERABLE_DOM_STORAGE])
+    with open(VULNERABLE_DOM_STORAGE) as f:
+        ast = javalang.parse.parse(f.read())
+
+    plugin.run(VULNERABLE_DOM_STORAGE, java_ast=ast)
     assert 2 == len(plugin.issues)
     for issue in plugin.issues:
         assert "webview" == issue.category

--- a/tests/test_scanner/test_scanner.py
+++ b/tests/test_scanner/test_scanner.py
@@ -11,25 +11,3 @@ def test_run(scanner, decompiler):
     scanner.decompiler = decompiler
     scanner.run()
     assert 0 < len(scanner.issues)
-
-    scanner.issues = []
-    scanner._run_checks("manifest")
-    assert SCANNER_ISSUES == len(scanner.issues)
-
-    # this should hit the other code path where
-    #   manifest_path is already set
-    scanner.issues = []
-    scanner._run_checks("manifest")
-    assert SCANNER_ISSUES == len(scanner.issues)
-
-    scanner.issues = []
-    scanner._run_checks("broadcast")
-    assert 0 < len(scanner.issues)
-
-    scanner.issues = []
-    scanner._run_checks("file")
-    assert 0 == len(scanner.issues)
-
-    scanner.issues = []
-    scanner._run_checks("intent")
-    assert 0 == len(scanner.issues)  # goatdroid doesnt have any of these vulnerabilities

--- a/tests/test_xml_files/test_goatdroid_manifest.xml
+++ b/tests/test_xml_files/test_goatdroid_manifest.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest android:versionCode="1" android:versionName="1.0" package="org.owasp.goatdroid.fourgoats"
+  xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-sdk android:minSdkVersion="9" android:targetSdkVersion="15" />
+    <application android:theme="@style/Theme.Sherlock" android:label="@string/app_name" android:icon="@drawable/icon" android:debuggable="true">
+        <activity android:label="@string/app_name" android:name=".activities.Main">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity android:label="@string/login" android:name=".activities.Login" />
+        <activity android:label="@string/register" android:name=".activities.Register" />
+        <activity android:label="@string/home" android:name=".activities.Home" />
+        <activity android:label="@string/checkin" android:name=".fragments.DoCheckin" />
+        <activity android:label="@string/checkins" android:name=".activities.Checkins" />
+        <activity android:label="@string/friends" android:name=".activities.Friends" />
+        <activity android:label="@string/history" android:name=".fragments.HistoryFragment" />
+        <activity android:label="@string/history" android:name=".activities.History" />
+        <activity android:label="@string/rewards" android:name=".activities.Rewards" />
+        <activity android:label="@string/add_venue" android:name=".activities.AddVenue" />
+        <activity android:label="@string/view_checkin" android:name=".activities.ViewCheckin" android:exported="true" />
+        <activity android:label="@string/my_friends" android:name=".fragments.MyFriends" />
+        <activity android:label="@string/search_for_friends" android:name=".fragments.SearchForFriends" />
+        <activity android:label="@string/profile" android:name=".activities.ViewProfile" android:exported="true" />
+        <activity android:label="@string/pending_friend_requests" android:name=".fragments.PendingFriendRequests" />
+        <activity android:label="@string/friend_request" android:name=".activities.ViewFriendRequest" />
+        <activity android:label="@string/my_rewards" android:name=".fragments.MyRewards" />
+        <activity android:label="@string/available_rewards" android:name=".fragments.AvailableRewards" />
+        <activity android:label="@string/preferences" android:name=".activities.Preferences" />
+        <activity android:label="@string/about" android:name=".activities.About" />
+        <activity android:label="@string/send_sms" android:name=".activities.SendSMS" />
+        <activity android:label="@string/comment" android:name=".activities.DoComment" />
+        <activity android:label="@string/history" android:name=".activities.UserHistory" />
+        <activity android:label="@string/destination_info" android:name=".activities.DestinationInfo" />
+        <activity android:label="@string/admin_home" android:name=".activities.AdminHome" />
+        <activity android:label="@string/admin_options" android:name=".activities.AdminOptions" />
+        <activity android:label="@string/reset_user_passwords" android:name=".fragments.ResetUserPasswords" />
+        <activity android:label="@string/delete_users" android:name=".fragments.DeleteUsers" />
+        <activity android:label="@string/reset_user_password" android:name=".activities.DoAdminPasswordReset" />
+        <activity android:label="@string/delete_users" android:name=".activities.DoAdminDeleteUser" />
+        <activity android:label="@string/authenticate" android:name=".activities.SocialAPIAuthentication" android:exported="true" />
+        <activity android:label="@string/app_name" android:name=".activities.GenericWebViewActivity" />
+        <service android:name=".services.LocationService">
+            <intent-filter>
+                <action android:name="org.owasp.goatdroid.fourgoats.services.LocationService" />
+            </intent-filter>
+        </service>
+        <receiver android:label="Send SMS" android:name=".broadcastreceivers.SendSMSNowReceiver">
+            <intent-filter>
+                <action android:name="org.owasp.goatdroid.fourgoats.SOCIAL_SMS" />
+            </intent-filter> >
+</receiver>
+    </application>
+    <uses-permission android:name="android.permission.SEND_SMS" />
+    <uses-permission android:name="android.permission.CALL_PHONE" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>


### PR DESCRIPTION
# Background
Previously we had thought about plugins by giving the most power to the user. This meant that we would pass plugins the file path and allow any plugins to do what they want with that specific file.

A big problem from this is that we calculate the Java AST and file contents multiple times for each plugin that is ran. Instead of doing this, I propose a new solution which is included in this PR.


# Proposal
We implement the [Observer pattern](https://en.wikipedia.org/wiki/Observer_pattern) that plugins can use to determine when they need to be ran. We also create abstractions for each type of plugin that can obtain the data they need to operate. Currently we have the following abstractions:

- FilePathPlugin: the most basic plugin, should call its `update` method whenever the file changes
- FileContentsPlugin: extends `FilePathPlugin` to read the file contents if possible
- JavaASTPlugin: extends the `FileContentsPlugin` to create the Java AST from the FileContents

This gives enormous time benefits, my calculations had the runtime dropping from 5 minutes to 1 minute (working only on java file, no decompilation).

# Drawbacks

- We are relying heavily on shared state, so it is possible one plugin can mess up results for other plugins that are being ran by changing class attributes that other plugins are using.
- Since we use shared state we cannot get 'true' async processes. The most we can do is run every plugin on the current file async, join them, and then move to the next file.
- We can get more strict on certain plugins by checking that the file type matches what we expect. For concrete FileContents plugins it would be recommended they check the filetype to reduce computation time that would not be helpful if the file is not what they expect.
- It is possible that this much abstraction can be confusing for users, we will need additional documentation around using these features.

# Conclusion
This rewrite passes all previous unit-tests (after reworking them for the new syntax). Some tests were changed minorly as we are doing checks in different places now.