### PR TITLE
Fixing setup.py to include dex2jar correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         QARK_DIR: [
             os.path.join("lib", "decompilers", "*.jar"),  # include any decompiler jar files
             os.path.join("lib", "apktool", "*.jar"),  # include apktool
-            os.path.join("lib", "dex2jar-2.0", "*"),  # include dex2jar
+            os.path.join("lib", "dex2jar-2.0", "*.*"),  # include dex2jar
             os.path.join("lib", "dex2jar-2.0", "lib", "*"),  # include dex2jar
             os.path.join("templates", "*.jinja"),  # include the reporting template files
         ] + exploit_apk_files,  # include all the java files required for creating an exploit APK


### PR DESCRIPTION
Hi team,

I tried to use `pip install .` to install qark recently in a vagrant machine and encountered the following error:

```
 can't copy 'qark/lib/dex2jar-2.0/lib': doesn't exist or not a regular file
```

I am not 100% familiar with setup.py but fixing this line to `*.*` to instruct pip to only copy files with extensions in dex2jar directory works. `*` would cause pip to attempt to copy the child folder `lib` which throw the error above.

San