### PR TITLE
Fix for #376 & #339

### DIFF
--- a/qark/decompiler/decompiler.py
+++ b/qark/decompiler/decompiler.py
@@ -26,9 +26,9 @@ DEX2JAR_INVOKE = "d2j_invoke.{extension}".format(extension=DEX2JAR_EXTENSION)
 
 DECOMPILERS_PATH = os.path.join(LIB_PATH, "decompilers")
 
-APK_TOOL_COMMAND = ("java -Djava.awt.headless=true -jar {apktool_path}/apktool.jar "
-                    "d {path_to_source} --no-src --force -m --output {build_directory}")
-DEX2JAR_COMMAND = "{dex2jar_path} {path_to_dex} -o {build_apk}.jar"
+APK_TOOL_COMMAND = ("java -Djava.awt.headless=true -jar \"{apktool_path}/apktool.jar\" "
+                    "d \"{path_to_source}\" --no-src --force -m --output \"{build_directory}\"")
+DEX2JAR_COMMAND = "{dex2jar_path} \"{path_to_dex}\" -o \"{build_apk}.jar\""
 
 
 def escape_windows_path(path):
@@ -111,13 +111,12 @@ class Decompiler(object):
             log.debug(".jar file path not found, trying to create dex file.")
             self.jar_path = self._run_dex2jar()
 
-        decompiler_command = escape_windows_path(
-            decompiler.command.format(path_to_decompiler=decompiler.path_to_decompiler,
-                                      jar=self.jar_path,
-                                      build_directory=self.build_directory))
+        decompiler_command = decompiler.command.format(path_to_decompiler=decompiler.path_to_decompiler,
+                                                       jar=self.jar_path,
+                                                       build_directory=self.build_directory)
 
         try:
-            retcode = subprocess.call(shlex.split(decompiler_command))
+            retcode = subprocess.call(decompiler_command,shell=True)
         except Exception:
             log.exception("%s failed to finish decompiling, continuing", decompiler.name)
         else:
@@ -145,14 +144,14 @@ class Decompiler(object):
 
         configure_apktool()
 
-        custom_apktool_command = escape_windows_path(APK_TOOL_COMMAND.format(apktool_path=APK_TOOL_PATH,
-                                                                             path_to_source=self.path_to_source,
-                                                                             build_directory=os.path.join(
-                                                                                 self.build_directory, "apktool")))
+        custom_apktool_command = APK_TOOL_COMMAND.format(apktool_path=APK_TOOL_PATH,
+                                                         path_to_source=self.path_to_source,
+                                                         build_directory=os.path.join(
+                                                             self.build_directory, "apktool"))
         log.debug("Calling APKTool with following command")
         log.debug(custom_apktool_command)
         try:
-            subprocess.call(shlex.split(custom_apktool_command))
+            subprocess.call(custom_apktool_command,shell=True)
         except Exception:
             log.exception("Failed to run APKTool with command: %s", custom_apktool_command)
             raise SystemExit("Failed to run APKTool")
@@ -194,16 +193,16 @@ class Decompiler(object):
 
         configure_dex2jar()
 
-        dex2jar_command = escape_windows_path(DEX2JAR_COMMAND.format(dex2jar_path=os.path.join(DEX2JAR_PATH,
-                                                                                               "d2j-dex2jar.{extension}".format(
-                                                                                                   extension=DEX2JAR_EXTENSION)),
-                                                                     path_to_dex=self.dex_path,
-                                                                     build_apk=os.path.join(self.build_directory,
-                                                                                            self.apk_name)))
+        dex2jar_command = DEX2JAR_COMMAND.format(dex2jar_path=os.path.join(DEX2JAR_PATH,
+                                                                           "d2j-dex2jar.{extension}".format(
+                                                                               extension=DEX2JAR_EXTENSION)),
+                                                 path_to_dex=self.dex_path,
+                                                 build_apk=os.path.join(self.build_directory,
+                                                                        self.apk_name))
 
         log.debug("Running dex2jar with command %s", dex2jar_command)
         try:
-            ret_code = subprocess.call(shlex.split(dex2jar_command))
+            ret_code = subprocess.call(dex2jar_command,shell=True)
             if ret_code != 0:
                 log.critical("Error running dex2jar command: %s", dex2jar_command)
                 raise SystemExit("Error running dex2jar")

--- a/qark/decompiler/external_decompiler.py
+++ b/qark/decompiler/external_decompiler.py
@@ -19,7 +19,7 @@ class CFR(ExternalDecompiler):
         ExternalDecompiler.__init__(self,
                                     name="cfr",
                                     path_to_decompiler=os.path.join(PATH_TO_DECOMPILERS, "cfr_0_124.jar"),
-                                    command="java -jar {path_to_decompiler} {jar} --outputdir {build_directory}/cfr")
+                                    command="java -jar \"{path_to_decompiler}\" \"{jar}\" --outputdir \"{build_directory}/cfr\"")
 
 
 class Procyon(ExternalDecompiler):
@@ -28,7 +28,7 @@ class Procyon(ExternalDecompiler):
                                     name="procyon",
                                     path_to_decompiler=os.path.join(PATH_TO_DECOMPILERS,
                                                                     "procyon-decompiler-1.0.jar"),
-                                    command="java -jar {path_to_decompiler} {jar} -o {build_directory}/procyon")
+                                    command="java -jar \"{path_to_decompiler}\" \"{jar}\" -o \"{build_directory}/procyon\"")
 
 
 class Fernflower(ExternalDecompiler):
@@ -37,7 +37,7 @@ class Fernflower(ExternalDecompiler):
                                     name="fernflower",
                                     path_to_decompiler=os.path.join(PATH_TO_DECOMPILERS,
                                                                     "fernflower.jar"),
-                                    command="java -jar {path_to_decompiler} -ren=1 {jar} {build_directory}/fernflower")
+                                    command="java -jar \"{path_to_decompiler}\" -ren=1 \"{jar}\" \"{build_directory}/fernflower\"")
 
 
 DECOMPILERS = (CFR(), Procyon(), Fernflower())

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -78,7 +78,7 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk, repo
             else:
                 click.secho("Please provide path to android SDK if building exploit APK.")
                 return
-            sdk_path.replace("\\","\\\\").replace("\\\\:","\\:") #Hugly patch for Windows build
+            sdk_path = sdk_path.replace("\\","\\\\") #Test for build
 
     # Debug controls the output to stderr, debug logs are ALWAYS stored in `qark_debug.log`
     if debug:

--- a/qark/qark.py
+++ b/qark/qark.py
@@ -49,9 +49,13 @@ logger = logging.getLogger(__name__)
               help="report output path.", show_default=True)
 @click.option("--keep-report/--no-keep-report", default=False,
               help="Append to final report file.", show_default=True)
+@click.option("--bypass-decompile/--no-bypass-decompile", default=False,
+              help="Resume after the decompilation", show_default=True)
+@click.option("--report/--no-report", default=False,
+              help="Resume after the decompilation", show_default=True)
 @click.version_option()
 @click.pass_context
-def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk, report_path, keep_report):
+def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk, report_path, keep_report, bypass_decompile,report):
     if not source:
         click.secho("Please pass a source for scanning through either --java or --apk")
         click.secho(ctx.get_help())
@@ -74,6 +78,7 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk, repo
             else:
                 click.secho("Please provide path to android SDK if building exploit APK.")
                 return
+            sdk_path.replace("\\","\\\\").replace("\\\\:","\\:") #Hugly patch for Windows build
 
     # Debug controls the output to stderr, debug logs are ALWAYS stored in `qark_debug.log`
     if debug:
@@ -83,9 +88,12 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk, repo
 
     initialize_logging(level)
 
-    click.secho("Decompiling...")
     decompiler = Decompiler(path_to_source=source, build_directory=build_path)
-    decompiler.run()
+    if  bypass_decompile:
+        click.secho("Skipping decompilation...")
+    else:
+        click.secho("Decompiling...")
+        decompiler.run()
 
     click.secho("Running scans...")
     path_to_source = decompiler.path_to_source if decompiler.source_code else decompiler.build_directory
@@ -94,10 +102,11 @@ def cli(ctx, sdk_path, build_path, debug, source, report_type, exploit_apk, repo
     scanner.run()
     click.secho("Finish scans...")
 
-    click.secho("Writing report...")
-    report = Report(issues=set(scanner.issues), report_path=report_path, keep_report=keep_report)
-    report_path = report.generate(file_type=report_type)
-    click.secho("Finish writing report to {report_path} ...".format(report_path=report_path))
+    if report:
+        click.secho("Writing report...")
+        report = Report(issues=set(scanner.issues), report_path=report_path, keep_report=keep_report)
+        report_path = report.generate(file_type=report_type)
+        click.secho("Finish writing report to {report_path} ...".format(report_path=report_path))
 
     if exploit_apk:
         click.secho("Building exploit APK...")


### PR DESCRIPTION
Hello,

It  fixes issue #376   and issue #339 

It was caused by a misshandling of shlex (didn't investigate this one)on decompiler files.
- shlex is removed
- the command is built as string
- parameter shell=True is added to the subprocess.call 

It was tested on Win10, with python 3.6.8,

Regards