### PR TITLE
Fix check_permissions.py typo

### DIFF
--- a/qark/plugins/generic/check_permissions.py
+++ b/qark/plugins/generic/check_permissions.py
@@ -22,7 +22,7 @@ ENFORCE_PERMISSION_REGEX = re.compile(
 class CheckPermissions(JavaASTPlugin):
     def __init__(self):
         super(CheckPermissions, self).__init__(category="manifest",
-                                               name="Potientially vulnerable check permission function called",
+                                               name="Potentially vulnerable check permission function called",
                                                description=CHECK_PERMISSIONS_DESCRIPTION)
         self.severity = Severity.WARNING
 


### PR DESCRIPTION
Just fix an small typo that got me a trouble when trying to automatize search of a vulnerability.